### PR TITLE
Add 155 missing i-shipped entries and fix malformed repo field

### DIFF
--- a/src/content/i-shipped/111-refactoring.mdx
+++ b/src/content/i-shipped/111-refactoring.mdx
@@ -1,0 +1,7 @@
+---
+summary: 1.1.1-refactoring
+repo: joeinnes/drinks
+mergeDate: 2023-09-08
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/30-prompt-to-prompts-1.mdx
+++ b/src/content/i-shipped/30-prompt-to-prompts-1.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  3.0: prompt to prompts (#1)
+repo: apostrophecms/apostrophe
+mergeDate: 2020-11-30
+prNumber: '2598'
+---
+* Updated to 'prompts'

--- a/src/content/i-shipped/add-a-512px-progressive-image-variant.mdx
+++ b/src/content/i-shipped/add-a-512px-progressive-image-variant.mdx
@@ -1,0 +1,10 @@
+---
+summary: add a 512px progressive image variant
+repo: garden-co/jazz
+mergeDate: 2026-01-16
+prNumber: '3376'
+---
+# Description
+Currently, we resize images to 256, 1024, and 2048 (plus the original).
+
+This is generally reasonable for thumbnails and full width content on different devices, but there's a big jump between 256 and 1024 for content that does not fill the width of a screen.

--- a/src/content/i-shipped/add-a-clickhandler-export-which-allows-you-to-handle-clicks-on-data-points.mdx
+++ b/src/content/i-shipped/add-a-clickhandler-export-which-allows-you-to-handle-clicks-on-data-points.mdx
@@ -1,0 +1,17 @@
+---
+summary: >-
+  add a 'clickHandler' export which allows you to handle clicks on data points
+repo: Mitcheljager/svelte-tiny-linked-charts
+mergeDate: 2022-08-21
+prNumber: '1'
+---
+clickHandler receives (key, index).
+
+Example:
+
+```
+  <LinkedChart
+    {data}
+    clickHandler={(key, i) => alert(`You clicked on ${key} in position ${i}`)}
+  />
+```

--- a/src/content/i-shipped/add-a-daily-excess-metric-which-shows-how-many-days-you-exceeded-the.mdx
+++ b/src/content/i-shipped/add-a-daily-excess-metric-which-shows-how-many-days-you-exceeded-the.mdx
@@ -1,0 +1,7 @@
+---
+summary: add a daily excess metric which shows how many days you exceeded the recommendations. Type fixes
+repo: joeinnes/drinks
+mergeDate: 2023-09-11
+prNumber: '2'
+---
+

--- a/src/content/i-shipped/add-a-delete-local-storage-option-to-the-inspector.mdx
+++ b/src/content/i-shipped/add-a-delete-local-storage-option-to-the-inspector.mdx
@@ -1,0 +1,11 @@
+---
+summary: >-
+  add a 'delete local storage' option to the inspector
+repo: garden-co/jazz
+mergeDate: 2025-09-09
+prNumber: '2884'
+---
+# Description
+- Added functionality to delete user's local storage from the inspector (behind a clear warning)
+- Added "destructive" variant to Button component with hover effect.
+- Introduced a reusable modal component.

--- a/src/content/i-shipped/add-a-docs-index-to-agentsmd.mdx
+++ b/src/content/i-shipped/add-a-docs-index-to-agentsmd.mdx
@@ -1,0 +1,9 @@
+---
+summary: add a docs index to AGENTS.md
+repo: garden-co/jazz
+mergeDate: 2026-02-11
+prNumber: '3445'
+---
+Per https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals, this is even more effective than skills.
+
+Added a generation script which runs when building the docs.

--- a/src/content/i-shipped/add-a-hash.mdx
+++ b/src/content/i-shipped/add-a-hash.mdx
@@ -1,0 +1,23 @@
+---
+summary: add a hash
+repo: garden-co/jazz
+mergeDate: 2025-12-15
+prNumber: '3283'
+---
+# Description
+Adds a hash to the URL to make the QR code and the link work
+
+## Manual testing instructions
+Check homepage link and QR code.
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [X] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a...

--- a/src/content/i-shipped/add-a-tip-explaining-http-only-cookies-issue.mdx
+++ b/src/content/i-shipped/add-a-tip-explaining-http-only-cookies-issue.mdx
@@ -1,0 +1,11 @@
+---
+summary: add a tip explaining HTTP Only cookies issue
+repo: directus/directus
+mergeDate: 2021-12-01
+prNumber: '9574'
+---
+Watching the Discord, I see this issue coming up fairly frequently, when someone is developing a front end app locally, and their app suddenly stops working with the message
+
+> Error: "refresh_token" is required in either the JSON payload or Cookie
+
+This tip explains the cause of the issue, and two different workarounds.

--- a/src/content/i-shipped/add-an-empty-state-to-artist-search.mdx
+++ b/src/content/i-shipped/add-an-empty-state-to-artist-search.mdx
@@ -1,0 +1,7 @@
+---
+summary: add an empty state to artist search
+repo: traist-web-services/elpea
+mergeDate: 2021-10-11
+prNumber: '9'
+---
+

--- a/src/content/i-shipped/add-cleanup-function-to-useeffect-example-of-dynamic-imports.mdx
+++ b/src/content/i-shipped/add-cleanup-function-to-useeffect-example-of-dynamic-imports.mdx
@@ -1,0 +1,18 @@
+---
+summary: >-
+  add cleanup function to 'useEffect' example of dynamic imports
+repo: tinacms/tinacms
+mergeDate: 2021-02-01
+prNumber: '1720'
+---
+<!--
+
+Thank you for contributing to TinaCMS!
+
+Several things must happen for your PR to be merged:
+
+1. It must successfully build, test, and lint your branch
+1. It must pass the dangerjs script
+2. It must be up-to-date with master
+3. It must be approved by at least 1 tinacms core member
+4.

--- a/src/content/i-shipped/add-custom-placeholders-for-image-components.mdx
+++ b/src/content/i-shipped/add-custom-placeholders-for-image-components.mdx
@@ -1,0 +1,12 @@
+---
+summary: add custom placeholders for Image components
+repo: garden-co/jazz
+mergeDate: 2025-10-22
+prNumber: '2937'
+---
+# Description
+Since Jazz v0.17.0, we've defaulted to *not* generating placeholder images by default. This meant that some users were surprised on upgrading to see flashes of alt text instead of a loading image.
+
+Although this is the browser's default behaviour, the experience can be somewhat jarring.
+
+This PR allows users to specify custom placeholder images (e.g. their brand).

--- a/src/content/i-shipped/add-defaultlayout-as-an-optional-property-in-markdownoptions.mdx
+++ b/src/content/i-shipped/add-defaultlayout-as-an-optional-property-in-markdownoptions.mdx
@@ -1,0 +1,7 @@
+---
+summary: add defaultLayout as an optional property in markdownOptions
+repo: joeinnes/astro
+mergeDate: 2022-01-06
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/add-documentation-of-optionsparamsendpoint-to-the-s3-section-of-readme.mdx
+++ b/src/content/i-shipped/add-documentation-of-optionsparamsendpoint-to-the-s3-section-of-readme.mdx
@@ -1,0 +1,7 @@
+---
+summary: add documentation of options.params.endpoint to the s3 section of readme
+repo: apostrophecms/uploadfs
+mergeDate: 2020-12-30
+prNumber: '63'
+---
+

--- a/src/content/i-shipped/add-documentation-on-using-nextimage.mdx
+++ b/src/content/i-shipped/add-documentation-on-using-nextimage.mdx
@@ -1,0 +1,7 @@
+---
+summary: add documentation on using next/image
+repo: tinacms/tina.io
+mergeDate: 2021-03-12
+prNumber: '798'
+---
+Fix #797

--- a/src/content/i-shipped/add-improved-docs-for-suspenseerror-boundaries.mdx
+++ b/src/content/i-shipped/add-improved-docs-for-suspenseerror-boundaries.mdx
@@ -1,0 +1,23 @@
+---
+summary: add improved docs for Suspense/Error Boundaries
+repo: garden-co/jazz
+mergeDate: 2026-01-13
+prNumber: '3359'
+---
+# Description
+Adds documentation and guidance on using Error Boundaries
+
+## Manual testing instructions
+N/A
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: Docs
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a version bump is...

--- a/src/content/i-shipped/add-jazz-workflow-world-documentation.mdx
+++ b/src/content/i-shipped/add-jazz-workflow-world-documentation.mdx
@@ -1,0 +1,23 @@
+---
+summary: add Jazz Workflow World documentation
+repo: garden-co/jazz
+mergeDate: 2025-11-11
+prNumber: '3135'
+---
+# Description
+Add Jazz Workflow World docs
+
+## Manual testing instructions
+Read along and try out the steps
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a version bump is...

--- a/src/content/i-shipped/add-joeinnes.mdx
+++ b/src/content/i-shipped/add-joeinnes.mdx
@@ -1,0 +1,7 @@
+---
+summary: add joeinnes
+repo: jlord/patchwork
+mergeDate: 2016-04-14
+prNumber: '10477'
+---
+

--- a/src/content/i-shipped/add-joeinnessvelte-image.mdx
+++ b/src/content/i-shipped/add-joeinnessvelte-image.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  add `@joeinnes/svelte-image`
+repo: svelte-society/sveltesociety.dev
+mergeDate: 2023-12-16
+prNumber: '176'
+---
+

--- a/src/content/i-shipped/add-pagination-and-fix-table-layout-issues.mdx
+++ b/src/content/i-shipped/add-pagination-and-fix-table-layout-issues.mdx
@@ -1,0 +1,13 @@
+---
+summary: add pagination and fix table layout issues
+repo: joeinnes/drinks
+mergeDate: 2025-08-20
+prNumber: '5'
+---
+This commit includes several updates to the drinks list table:
+
+1.  **Adds a pagination feature** with 'Previous' and 'Next' controls to allow users to navigate through the list of drinks.
+
+2.  **Fixes table layout overflow issues** by implementing a `table-fixed` layout and applying strict and responsive widths to the columns. This prevents long drink names from breaking the layout.
+
+3.

--- a/src/content/i-shipped/add-some-skills-and-reference-material.mdx
+++ b/src/content/i-shipped/add-some-skills-and-reference-material.mdx
@@ -1,0 +1,17 @@
+---
+summary: add some skills and reference material
+repo: garden-co/jazz
+mergeDate: 2026-01-30
+prNumber: '3402'
+---
+# Description
+Adds some skills for use by LLMs
+
+## Manual testing instructions
+Copy these skills to your `.claude` or `.cursor` folder in a new project. See if they make your LLM better at Jazz.
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [ ] Tests have not been updated, because: 
+- [x] I need help with writing tests: I am fairly sure that these are useful, but LLM feedback is fairly...

--- a/src/content/i-shipped/add-svelte-kit-to-ignored-paths.mdx
+++ b/src/content/i-shipped/add-svelte-kit-to-ignored-paths.mdx
@@ -1,0 +1,7 @@
+---
+summary: add .svelte-kit to ignored paths
+repo: vercel/workflow
+mergeDate: 2025-11-13
+prNumber: '276'
+---
+

--- a/src/content/i-shipped/add-svelte-provider-documentation-and-metadata.mdx
+++ b/src/content/i-shipped/add-svelte-provider-documentation-and-metadata.mdx
@@ -1,0 +1,7 @@
+---
+summary: add Svelte provider documentation and metadata
+repo: garden-co/jazz
+mergeDate: 2025-05-19
+prNumber: '2246'
+---
+Closes #2245

--- a/src/content/i-shipped/add-w-full-to-the-pagefind-container-div.mdx
+++ b/src/content/i-shipped/add-w-full-to-the-pagefind-container-div.mdx
@@ -1,0 +1,7 @@
+---
+summary: add w-full to the pagefind container div
+repo: garden-co/jazz
+mergeDate: 2025-06-09
+prNumber: '2467'
+---
+Fixes #2466

--- a/src/content/i-shipped/added-a-time-to-station-parameter.mdx
+++ b/src/content/i-shipped/added-a-time-to-station-parameter.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  added a 'time-to-station' parameter
+repo: derhuerst/vbb-anybar
+mergeDate: 2017-10-02
+prNumber: '2'
+---
+Added a 'time-to-station' configuration possibility allowing users to specify in minutes how long it takes them to walk to (or indeed drive to, swim to, fly to, etc.) their departure station

--- a/src/content/i-shipped/added-an-options-property-to-set-headings-manually.mdx
+++ b/src/content/i-shipped/added-an-options-property-to-set-headings-manually.mdx
@@ -1,0 +1,7 @@
+---
+summary: added an options property to set headings manually
+repo: PButcher/flipdown
+mergeDate: 2020-04-27
+prNumber: '29'
+---
+Adds the possibility to define a headings array of length 4, potentially fixing #25

--- a/src/content/i-shipped/added-chatwoot.mdx
+++ b/src/content/i-shipped/added-chatwoot.mdx
@@ -1,0 +1,7 @@
+---
+summary: added chatwoot
+repo: traist-web-services/traist
+mergeDate: 2021-01-24
+prNumber: '23'
+---
+Integrate Chatwoot

--- a/src/content/i-shipped/added-details-for-semya.mdx
+++ b/src/content/i-shipped/added-details-for-semya.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  added details for Sem'ya
+repo: osmlab/name-suggestion-index
+mergeDate: 2018-10-27
+prNumber: '2165'
+---
+Fixes #1787

--- a/src/content/i-shipped/added-documentation-for-tourremovestep-fixes-278.mdx
+++ b/src/content/i-shipped/added-documentation-for-tourremovestep-fixes-278.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  added documentation for tour.removeStep (fixes #278)
+repo: shipshapecode/shepherd
+mergeDate: 2018-10-29
+prNumber: '289'
+---
+Resolves #278

--- a/src/content/i-shipped/added-links-to-sections.mdx
+++ b/src/content/i-shipped/added-links-to-sections.mdx
@@ -1,0 +1,7 @@
+---
+summary: added links to sections
+repo: devcenter-square/disease-info-ui
+mergeDate: 2016-10-15
+prNumber: '36'
+---
+Hope this fits your needs - popped a UL at the top of the page, with links to each subheading.

--- a/src/content/i-shipped/added-missing-close-curly-brace.mdx
+++ b/src/content/i-shipped/added-missing-close-curly-brace.mdx
@@ -1,0 +1,7 @@
+---
+summary: added missing close curly brace
+repo: apostrophecms-legacy/apostrophe-palette
+mergeDate: 2020-04-22
+prNumber: '21'
+---
+A closing curly brace was missing in the readme (closing the 'apostrophe-palette-global' object). This adds it.

--- a/src/content/i-shipped/added-myself.mdx
+++ b/src/content/i-shipped/added-myself.mdx
@@ -1,0 +1,7 @@
+---
+summary: added myself
+repo: abhijitparida/hacktobermap
+mergeDate: 2018-10-28
+prNumber: '206'
+---
+

--- a/src/content/i-shipped/added-newer-mockup-screenshot.mdx
+++ b/src/content/i-shipped/added-newer-mockup-screenshot.mdx
@@ -1,0 +1,7 @@
+---
+summary: added newer mockup screenshot
+repo: traist-web-services/elpea
+mergeDate: 2021-10-11
+prNumber: '8'
+---
+

--- a/src/content/i-shipped/added-noncritical-css.mdx
+++ b/src/content/i-shipped/added-noncritical-css.mdx
@@ -1,0 +1,7 @@
+---
+summary: added noncritical CSS
+repo: joeinnes/joeinnes.github.io
+mergeDate: 2016-05-11
+prNumber: '3'
+---
+

--- a/src/content/i-shipped/added-note-on-when-option.mdx
+++ b/src/content/i-shipped/added-note-on-when-option.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  added note on 'when' option
+repo: derhuerst/hafas-departures-in-direction
+mergeDate: 2017-10-02
+prNumber: '4'
+---
+Turns out, 'when' is supported already as a number of milliseconds added to Date.now(), it's just missing from the readme. Closes #3

--- a/src/content/i-shipped/added-reactive-timing-and-subscriptions-logic.mdx
+++ b/src/content/i-shipped/added-reactive-timing-and-subscriptions-logic.mdx
@@ -1,0 +1,7 @@
+---
+summary: added reactive timing and subscriptions logic
+repo: joeinnes/chat
+mergeDate: 2015-10-16
+prNumber: '16'
+---
+…UI implemented.

--- a/src/content/i-shipped/added-websockets.mdx
+++ b/src/content/i-shipped/added-websockets.mdx
@@ -1,0 +1,7 @@
+---
+summary: added WebSockets
+repo: jesslark/dictionary
+mergeDate: 2019-07-06
+prNumber: '96'
+---
+

--- a/src/content/i-shipped/adjust-prominence-of-node-20-alert.mdx
+++ b/src/content/i-shipped/adjust-prominence-of-node-20-alert.mdx
@@ -1,0 +1,23 @@
+---
+summary: adjust prominence of Node 20 alert
+repo: garden-co/jazz
+mergeDate: 2025-09-18
+prNumber: '2931'
+---
+# Description
+Moves Node 20 alert to a less prominent and aggressive bold note under the content, rather than a full alert block.
+
+## Manual testing instructions
+N/A
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ]...

--- a/src/content/i-shipped/allow-passing-version-to-knex.mdx
+++ b/src/content/i-shipped/allow-passing-version-to-knex.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  allow passing 'version' to Knex
+repo: directus/directus
+mergeDate: 2022-01-10
+prNumber: '10960'
+---
+Fixes #10941 by treating `DB_VERSION` as a special env var which needs to be added to the top level Knex configuration rather than merged into the connection object.

--- a/src/content/i-shipped/api-reference.mdx
+++ b/src/content/i-shipped/api-reference.mdx
@@ -1,0 +1,8 @@
+---
+summary: aPI Reference
+repo: garden-co/jazz
+mergeDate: 2026-01-15
+prNumber: '3355'
+---
+# Description
+Adds a CoValue API reference guide, trimming the key APIs for interacting with CoValues back as much as possible, while still being useful for folks with all levels of familiarity with Jazz.

--- a/src/content/i-shipped/autogenerate-better_auth_secret.mdx
+++ b/src/content/i-shipped/autogenerate-better_auth_secret.mdx
@@ -1,0 +1,13 @@
+---
+summary: autogenerate BETTER_AUTH_SECRET
+repo: garden-co/jazz
+mergeDate: 2026-02-13
+prNumber: '3458'
+---
+Currently, building the monorepo fails because the `betterauth-svelte` example imports `BETTER_AUTH_SECRET` from `$env/static/private`, which requires a `.env` file to exist. Since `.env` is gitignored, fresh clones and CI always hit this error:
+
+```
+Error: Module '"$env/static/private"' has no exported member 'BETTER_AUTH_SECRET'.
+```
+
+This PR adds a small Node script (`scripts/ensure-env.

--- a/src/content/i-shipped/channel-permissions.mdx
+++ b/src/content/i-shipped/channel-permissions.mdx
@@ -1,0 +1,7 @@
+---
+summary: channel permissions
+repo: joeinnes/chat
+mergeDate: 2015-10-09
+prNumber: '14'
+---
+

--- a/src/content/i-shipped/clarify-polyfill-installation-instructions-in-react-native-setup.mdx
+++ b/src/content/i-shipped/clarify-polyfill-installation-instructions-in-react-native-setup.mdx
@@ -1,0 +1,25 @@
+---
+summary: clarify polyfill installation instructions in React Native setup
+repo: garden-co/jazz
+mergeDate: 2025-12-04
+prNumber: '3240'
+---
+# Description
+Correct 'install' wording to 'apply'.
+
+## Manual testing instructions
+
+N/A
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a version bump is required
+- [ ] I've updated...

--- a/src/content/i-shipped/clarify-use-case-for-ensureloaded.mdx
+++ b/src/content/i-shipped/clarify-use-case-for-ensureloaded.mdx
@@ -1,0 +1,25 @@
+---
+summary: clarify use case for ensureLoaded
+repo: garden-co/jazz
+mergeDate: 2025-09-29
+prNumber: '2971'
+---
+# Description
+Addresses community feedback: 
+
+https://discord.com/channels/1139617727565271160/1139621689882321009/1421103685357932564
+
+## Manual testing instructions
+
+
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [X] Tests have not been updated, because: Docs
+- [ ] I need help with writing tests
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+-...

--- a/src/content/i-shipped/claude-improvements.mdx
+++ b/src/content/i-shipped/claude-improvements.mdx
@@ -1,0 +1,15 @@
+---
+summary: claude improvements
+repo: spicygolf/spicy
+mergeDate: 2026-01-17
+prNumber: '333'
+---
+Updates Claude files to match Jazz's latest updates.
+
+
+## Summary by CodeRabbit
+
+* **Documentation**
+  * Switched schema guidance to constant-based definitions and simplified schema patterns.
+  * Clarified ownership: every value needs an owning group; nested values inherit by default.
+  * Expanded migration guidance and field-deletion vs undefined semantics.

--- a/src/content/i-shipped/correct-spelling-of-google.mdx
+++ b/src/content/i-shipped/correct-spelling-of-google.mdx
@@ -1,0 +1,7 @@
+---
+summary: correct spelling of Google
+repo: yogiben/meteor-starter
+mergeDate: 2016-07-21
+prNumber: '116'
+---
+googe -> google

--- a/src/content/i-shipped/corrected-spelling.mdx
+++ b/src/content/i-shipped/corrected-spelling.mdx
@@ -1,0 +1,7 @@
+---
+summary: corrected spelling
+repo: electerious/Ackee
+mergeDate: 2020-11-28
+prNumber: '198'
+---
+

--- a/src/content/i-shipped/correcting-typo-in-gitignore.mdx
+++ b/src/content/i-shipped/correcting-typo-in-gitignore.mdx
@@ -1,0 +1,7 @@
+---
+summary: correcting typo in .gitignore
+repo: thejsj/passport-rethinkdb-tutorial
+mergeDate: 2017-08-08
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/cors-update.mdx
+++ b/src/content/i-shipped/cors-update.mdx
@@ -1,0 +1,7 @@
+---
+summary: cors update
+repo: joeinnes/bubi-bikes
+mergeDate: 2021-11-13
+prNumber: '3'
+---
+Update CORS proxy

--- a/src/content/i-shipped/create-projectsjson.mdx
+++ b/src/content/i-shipped/create-projectsjson.mdx
@@ -1,0 +1,7 @@
+---
+summary: create projects.json
+repo: joeinnes/joeinnes.github.io
+mergeDate: 2016-11-23
+prNumber: '4'
+---
+

--- a/src/content/i-shipped/create-readme.mdx
+++ b/src/content/i-shipped/create-readme.mdx
@@ -1,0 +1,7 @@
+---
+summary: create README
+repo: joeinnes/chicken-dinner-timer
+mergeDate: 2022-10-28
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/create-traistcoukmd.mdx
+++ b/src/content/i-shipped/create-traistcoukmd.mdx
@@ -1,0 +1,7 @@
+---
+summary: create traist.co.uk.md
+repo: bradleytaunt/1mb-club
+mergeDate: 2021-12-02
+prNumber: '839'
+---
+

--- a/src/content/i-shipped/created-fizzbuzz-implementation-using-ugly-ternary.mdx
+++ b/src/content/i-shipped/created-fizzbuzz-implementation-using-ugly-ternary.mdx
@@ -1,0 +1,7 @@
+---
+summary: created fizzbuzz implementation using ugly ternary
+repo: awesome-examples/fizzbuzz
+mergeDate: 2018-10-28
+prNumber: '50'
+---
+

--- a/src/content/i-shipped/dev.mdx
+++ b/src/content/i-shipped/dev.mdx
@@ -1,0 +1,7 @@
+---
+summary: dev
+repo: joeinnes/chat
+mergeDate: 2015-10-05
+prNumber: '4'
+---
+Merging in Dev

--- a/src/content/i-shipped/docs-correct-example-of-getgithubfile-usage-with-incorrect-parameters.mdx
+++ b/src/content/i-shipped/docs-correct-example-of-getgithubfile-usage-with-incorrect-parameters.mdx
@@ -1,0 +1,18 @@
+---
+summary: >-
+  (docs): correct example of getGithubFile usage with incorrect parameters
+repo: tinacms/tinacms
+mergeDate: 2021-01-19
+prNumber: '1692'
+---
+<!--
+
+Thank you for contributing to TinaCMS!
+
+Several things must happen for your PR to be merged:
+
+1. It must successfully build, test, and lint your branch
+1. It must pass the dangerjs script
+2. It must be up-to-date with master
+3. It must be approved by at least 1 tinacms core member
+4.

--- a/src/content/i-shipped/docs-update-for-tinacmstinacms1703.mdx
+++ b/src/content/i-shipped/docs-update-for-tinacmstinacms1703.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  docs update for tinacms/tinacms#1703
+repo: tinacms/tina.io
+mergeDate: 2021-02-08
+prNumber: '786'
+---
+

--- a/src/content/i-shipped/docsoptional-references.mdx
+++ b/src/content/i-shipped/docsoptional-references.mdx
@@ -1,0 +1,10 @@
+---
+summary: docs/optional references
+repo: garden-co/jazz
+mergeDate: 2025-08-01
+prNumber: '2655'
+---
+# Description
+Expands and updates the 'Optional References' section of the docs to reflect the boundaries between Zod schemas and CoValue schemas being more clearly defined in https://github.com/garden-co/jazz/pull/2650
+
+Also includes a couple of 'drive-by' fixes on twoslash errors.

--- a/src/content/i-shipped/docsquick-fixes.mdx
+++ b/src/content/i-shipped/docsquick-fixes.mdx
@@ -1,0 +1,24 @@
+---
+summary: docs/quick fixes
+repo: garden-co/jazz
+mergeDate: 2025-09-05
+prNumber: '2869'
+---
+# Description
+A bunch of small fixes to docs
+
+## Manual testing instructions
+No testing required
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [X] Tests have not been updated, because: Docs.
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a version bump is required
+- [ ]...

--- a/src/content/i-shipped/document-dealing-with-complex-getters.mdx
+++ b/src/content/i-shipped/document-dealing-with-complex-getters.mdx
@@ -1,0 +1,23 @@
+---
+summary: document dealing with complex getters
+repo: garden-co/jazz
+mergeDate: 2026-01-13
+prNumber: '3280'
+---
+# Description
+Add some quick explanation on how to avoid complex circular references by using a shallowly loaded schema
+
+## Manual testing instructions
+N/A
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: Docs
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've...

--- a/src/content/i-shipped/edit-messages.mdx
+++ b/src/content/i-shipped/edit-messages.mdx
@@ -1,0 +1,7 @@
+---
+summary: edit messages
+repo: joeinnes/chat
+mergeDate: 2015-10-08
+prNumber: '8'
+---
+Merging into master.

--- a/src/content/i-shipped/enable-dark-mode-support-for-minimal-to-do-list-example.mdx
+++ b/src/content/i-shipped/enable-dark-mode-support-for-minimal-to-do-list-example.mdx
@@ -1,0 +1,24 @@
+---
+summary: enable dark mode support for minimal to-do list example
+repo: garden-co/jazz
+mergeDate: 2026-01-27
+prNumber: '3411'
+---
+# Description
+Inline the SVG to enable styling with CSS
+
+## Manual testing instructions
+
+Check the landing page for the docs
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a version...

--- a/src/content/i-shipped/enable-monitor-to-keep-running-in-case-apostrophe-cant-start.mdx
+++ b/src/content/i-shipped/enable-monitor-to-keep-running-in-case-apostrophe-cant-start.mdx
@@ -1,0 +1,10 @@
+---
+summary: >-
+  enable monitor to keep running in case Apostrophe can't start
+repo: apostrophecms-legacy/apostrophe-monitor
+mergeDate: 2020-04-24
+prNumber: '7'
+---
+Current behaviour: if Apostrophe can't start (eg: syntax error in a module's index.js), monitor exits to the terminal.
+
+This PR allows monitor to continue running in case Apostrophe doesn't start, and instead runs a basic HTTP server which will return the error message and stack dump, until the error is fixed and Apostrophe can run successfully again.

--- a/src/content/i-shipped/ensure-params-are-set-in-creates-and-removes.mdx
+++ b/src/content/i-shipped/ensure-params-are-set-in-creates-and-removes.mdx
@@ -1,0 +1,14 @@
+---
+summary: ensure params are set in creates and removes
+repo: feathersjs-ecosystem/feathers-vuex
+mergeDate: 2018-09-17
+prNumber: '165'
+---
+Closes #156
+
+### Summary
+
+(If you have not already please refer to the contributing guideline as [described
+here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))
+
+- [x] Tell us about the problem your pull request is solving.

--- a/src/content/i-shipped/explain-double-prime-symbol-better.mdx
+++ b/src/content/i-shipped/explain-double-prime-symbol-better.mdx
@@ -1,0 +1,7 @@
+---
+summary: explain double prime symbol better
+repo: joeinnes/double-prime-vowels
+mergeDate: 2022-10-28
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/export-singlecofeedentry.mdx
+++ b/src/content/i-shipped/export-singlecofeedentry.mdx
@@ -1,0 +1,24 @@
+---
+summary: export SingleCoFeedEntry
+repo: garden-co/jazz
+mergeDate: 2025-11-03
+prNumber: '3134'
+---
+# Description
+We don't currently export the `SingleCoFeedEntry` type, although other similar types are exported.
+
+## Manual testing instructions
+
+N/A
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [ ] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated...

--- a/src/content/i-shipped/extend-auth-quickstart-to-demonstrate-passkey-auth.mdx
+++ b/src/content/i-shipped/extend-auth-quickstart-to-demonstrate-passkey-auth.mdx
@@ -1,0 +1,21 @@
+---
+summary: extend auth quickstart to demonstrate passkey auth
+repo: garden-co/jazz
+mergeDate: 2025-10-06
+prNumber: '3002'
+---
+# Description
+Extends the existing quickstart auth to demonstrate passkey auth (showing how to use multiple auth methods)
+
+## Manual testing instructions
+Review the docs/authentication/quickstart guide
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: Docs
+- [ ] I need help with writing tests
+
+
+## Checklist
+- [ ] I've updated the part of the docs...

--- a/src/content/i-shipped/filter-all-the-code-snippets-to-show-only-the-framework-relevant-snippets.mdx
+++ b/src/content/i-shipped/filter-all-the-code-snippets-to-show-only-the-framework-relevant-snippets.mdx
@@ -1,0 +1,12 @@
+---
+summary: filter all the code snippets to show only the framework relevant snippets
+repo: garden-co/jazz
+mergeDate: 2025-10-14
+prNumber: '3048'
+---
+# Description
+Allows passing a framework to the mock components through esbuild, meaning we can render only the relevant content based on the specific framework
+
+## Manual testing instructions
+
+Use the .

--- a/src/content/i-shipped/first-class-svelte-support-for-better-auth.mdx
+++ b/src/content/i-shipped/first-class-svelte-support-for-better-auth.mdx
@@ -1,6 +1,6 @@
 ---
 summary: first class Svelte support for Better Auth
-repo: '3285'
+repo: garden-co/jazz
 mergeDate: 2026-01-08
 prNumber: '3285'
 ---

--- a/src/content/i-shipped/first-commit.mdx
+++ b/src/content/i-shipped/first-commit.mdx
@@ -1,0 +1,7 @@
+---
+summary: first commit
+repo: joeinnes/help-the-homeless
+mergeDate: 2016-11-13
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/fix-3186.mdx
+++ b/src/content/i-shipped/fix-3186.mdx
@@ -1,0 +1,25 @@
+---
+summary: >-
+  fix #3186
+repo: garden-co/jazz
+mergeDate: 2025-11-18
+prNumber: '3187'
+---
+# Description
+Adds an asterisk to fix a typo in the docs.
+
+## Manual testing instructions
+N/A
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [ ] Tests have not been updated, because: 
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a version bump is required
+- [ ] I've...

--- a/src/content/i-shipped/fix-build-issues.mdx
+++ b/src/content/i-shipped/fix-build-issues.mdx
@@ -1,0 +1,23 @@
+---
+summary: fix build issues
+repo: garden-co/jazz
+mergeDate: 2025-10-07
+prNumber: '3009'
+---
+# Description
+Worked out an issue with conflicting static paths for the naked route.
+
+## Manual testing instructions
+Build the homepage.
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset,...

--- a/src/content/i-shipped/fix-charset-issues-on-mysql-fixes-388.mdx
+++ b/src/content/i-shipped/fix-charset-issues-on-mysql-fixes-388.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  fix charset issues on mySQL (fixes #388)
+repo: umami-software/umami
+mergeDate: 2020-11-28
+prNumber: '389'
+---
+Create tables with utf8 charset to fix #388

--- a/src/content/i-shipped/fix-chat-demo.mdx
+++ b/src/content/i-shipped/fix-chat-demo.mdx
@@ -1,0 +1,23 @@
+---
+summary: fix chat demo
+repo: garden-co/jazz
+mergeDate: 2025-12-15
+prNumber: '3279'
+---
+# Description
+This PR listens to the correct event emitted by the iframe
+
+## Manual testing instructions
+Check in the Vercel preview
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a...

--- a/src/content/i-shipped/fix-docs-check-if-cleanup-is-needed-before-cleaning-up.mdx
+++ b/src/content/i-shipped/fix-docs-check-if-cleanup-is-needed-before-cleaning-up.mdx
@@ -1,0 +1,18 @@
+---
+summary: >-
+  fix docs: check if cleanup is needed before cleaning up
+repo: tinacms/tinacms
+mergeDate: 2021-02-02
+prNumber: '1727'
+---
+<!--
+
+Thank you for contributing to TinaCMS!
+
+Several things must happen for your PR to be merged:
+
+1. It must successfully build, test, and lint your branch
+1. It must pass the dangerjs script
+2. It must be up-to-date with master
+3. It must be approved by at least 1 tinacms core member
+4.

--- a/src/content/i-shipped/fix-error-in-docs.mdx
+++ b/src/content/i-shipped/fix-error-in-docs.mdx
@@ -1,0 +1,7 @@
+---
+summary: fix error in docs
+repo: humaans/figbird
+mergeDate: 2020-08-03
+prNumber: '10'
+---
+

--- a/src/content/i-shipped/fix-expo-placeholders.mdx
+++ b/src/content/i-shipped/fix-expo-placeholders.mdx
@@ -1,0 +1,13 @@
+---
+summary: fix expo placeholders
+repo: garden-co/jazz
+mergeDate: 2026-01-16
+prNumber: '3375'
+---
+# Description
+Expo Image Manipulator returns a bare base64 string, which means that the images uploaded from Expo clients had invalid placeholders.
+
+This fixes. 
+
+## Manual testing instructions
+Build and install the chat app, upload some images. Check that the placeholder URL is correctly set with the `data` prefix.

--- a/src/content/i-shipped/fix-homepage-build-issues.mdx
+++ b/src/content/i-shipped/fix-homepage-build-issues.mdx
@@ -1,0 +1,10 @@
+---
+summary: fix homepage build issues
+repo: garden-co/jazz
+mergeDate: 2025-11-13
+prNumber: '3179'
+---
+# Description
+Homepage builds are failing since merging 3178 but 3178 built successfully in preview: https://vercel.com/gcmp/jazz-homepage/4GFURBFsp8apUe3zuKqcnKDyCyKW
+
+I still don't know why the `// @ts-expect-error` is causing issues on Vercel but not locally (in fact, the opposite), but this will unblock homepage builds while I work it out.

--- a/src/content/i-shipped/fix-http-api-link-in-inboxmdx-fixes-2687.mdx
+++ b/src/content/i-shipped/fix-http-api-link-in-inboxmdx-fixes-2687.mdx
@@ -1,0 +1,14 @@
+---
+summary: >-
+  fix HTTP API link in inbox.mdx. Fixes #2687
+repo: garden-co/jazz
+mergeDate: 2025-08-01
+prNumber: '2689'
+---
+# Description
+
+Quick docs-only fix to correct a link which had `.mdx` at the end. Thanks @nicolasembleton for the report (fixes #2687)!
+
+## Manual testing instructions
+
+Run in dev mode, click the link from the issue. Should navigate without issues to the correct page.

--- a/src/content/i-shipped/fix-issue-when-code-sample-is-formatted.mdx
+++ b/src/content/i-shipped/fix-issue-when-code-sample-is-formatted.mdx
@@ -1,0 +1,23 @@
+---
+summary: fix issue when code sample is formatted
+repo: garden-co/jazz
+mergeDate: 2025-11-24
+prNumber: '3184'
+---
+# Description
+Minor fix to svelte permissions docs: // [!code hide] only hides the first line of a multi-line expression
+
+## Manual testing instructions
+
+Check the first code sample under Permissions & Sharing / Sharing # Invites (Svelte)
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ]...

--- a/src/content/i-shipped/fix-issue-with-reactivity-and-add-jazz-inspector.mdx
+++ b/src/content/i-shipped/fix-issue-with-reactivity-and-add-jazz-inspector.mdx
@@ -1,0 +1,7 @@
+---
+summary: fix issue with reactivity and add Jazz Inspector
+repo: MentalGear/jazz-svelte-debug-mrexample
+mergeDate: 2025-05-09
+prNumber: '1'
+---
+Derive `me` and `itemImages` using `$derived` to ensure reactivity and simplify state management. Additionally, handle missing image resolution gracefully by returning a placeholder data URL instead of throwing an error.

--- a/src/content/i-shipped/fix-missing-in-template-literal.mdx
+++ b/src/content/i-shipped/fix-missing-in-template-literal.mdx
@@ -1,0 +1,7 @@
+---
+summary: fix missing $ in template literal
+repo: garden-co/jazz
+mergeDate: 2025-05-16
+prNumber: '2261'
+---
+Fixes #2260

--- a/src/content/i-shipped/fix-missing-link-to-the-betterauth-database-adapter-doc.mdx
+++ b/src/content/i-shipped/fix-missing-link-to-the-betterauth-database-adapter-doc.mdx
@@ -1,0 +1,22 @@
+---
+summary: fix missing link to the BetterAuth Database Adapter doc
+repo: garden-co/jazz
+mergeDate: 2025-10-15
+prNumber: '3055'
+---
+# Description
+At some point the BA DB Adapter link got dropped from the nav. This quick PR adds it back.
+
+## Manual testing instructions
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [X] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset,...

--- a/src/content/i-shipped/fix-readme-typo.mdx
+++ b/src/content/i-shipped/fix-readme-typo.mdx
@@ -1,0 +1,9 @@
+---
+summary: fix readme typo
+repo: hiroki0525/idle-task
+mergeDate: 2022-11-24
+prNumber: '16'
+---
+And in keeping with Muphry's law, commit message contains a typo.
+
+Fixes 'prioriy' in the readme to 'priority'.

--- a/src/content/i-shipped/fix-tojson-serialisation-for-corecord.mdx
+++ b/src/content/i-shipped/fix-tojson-serialisation-for-corecord.mdx
@@ -1,0 +1,18 @@
+---
+summary: >-
+  fix `toJSON()` serialisation for `co.record`
+repo: garden-co/jazz
+mergeDate: 2026-02-07
+prNumber: '3444'
+---
+The catchall on CoRecords was trapping the `toJSON` call, resulting in incorrect serialisation behaviour of nested CoRecords.
+
+Tests have been added.
+
+
+
+---
+
+> [!NOTE]
+> **Low Risk**
+> Scoped to serialization/schema lookup logic and adds targeted test coverage; low risk aside from potential edge cases in proxy trapping for non-string keys.

--- a/src/content/i-shipped/fix-typo-in-heading.mdx
+++ b/src/content/i-shipped/fix-typo-in-heading.mdx
@@ -1,0 +1,7 @@
+---
+summary: fix typo in heading
+repo: apostrophecms/apostrophe-documentation
+mergeDate: 2021-01-04
+prNumber: '332'
+---
+

--- a/src/content/i-shipped/fix-typo.mdx
+++ b/src/content/i-shipped/fix-typo.mdx
@@ -1,0 +1,7 @@
+---
+summary: fix typo
+repo: caprover/one-click-apps
+mergeDate: 2022-08-07
+prNumber: '694'
+---
+STMP -> SMTP

--- a/src/content/i-shipped/fixed-insert-vulnerability.mdx
+++ b/src/content/i-shipped/fixed-insert-vulnerability.mdx
@@ -1,0 +1,7 @@
+---
+summary: fixed insert vulnerability
+repo: joeinnes/chat
+mergeDate: 2015-10-17
+prNumber: '20'
+---
+Merging subs into dev

--- a/src/content/i-shipped/fixes-794.mdx
+++ b/src/content/i-shipped/fixes-794.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  fixes #794
+repo: anchorcms/anchor-cms
+mergeDate: 2015-06-26
+prNumber: '819'
+---
+Tidied up PR.

--- a/src/content/i-shipped/flash-fix.mdx
+++ b/src/content/i-shipped/flash-fix.mdx
@@ -1,0 +1,7 @@
+---
+summary: flash fix
+repo: joeinnes/joeinnes.github.io
+mergeDate: 2016-05-11
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/fluid-typography-enabled.mdx
+++ b/src/content/i-shipped/fluid-typography-enabled.mdx
@@ -1,0 +1,7 @@
+---
+summary: fluid typography enabled
+repo: joeinnes/joeinnes.github.io
+mergeDate: 2016-05-11
+prNumber: '2'
+---
+

--- a/src/content/i-shipped/git_ui-give-visual-feedback-when-an-operation-is-pending.mdx
+++ b/src/content/i-shipped/git_ui-give-visual-feedback-when-an-operation-is-pending.mdx
@@ -1,0 +1,15 @@
+---
+summary: >-
+  git_ui: Give visual feedback when an operation is pending
+repo: zed-industries/zed
+mergeDate: 2025-11-01
+prNumber: '41686'
+---
+Currently, if a commit operation takes some time, there's no visual feedback in the UI that anything's happening.
+
+This PR changes the colour of the text on the button to the `Color::Disabled` colour when a commit operation is pending.
+
+Release Notes:
+
+- Improved UI feedback in the Git panel when a commit is in progress.
+- Let's Git Together

--- a/src/content/i-shipped/glitch-2.mdx
+++ b/src/content/i-shipped/glitch-2.mdx
@@ -1,0 +1,7 @@
+---
+summary: glitch
+repo: joeinnes/save-the-date
+mergeDate: 2019-12-26
+prNumber: '2'
+---
+

--- a/src/content/i-shipped/glitch-3.mdx
+++ b/src/content/i-shipped/glitch-3.mdx
@@ -1,0 +1,7 @@
+---
+summary: glitch
+repo: joeinnes/wedding-app
+mergeDate: 2019-10-28
+prNumber: '2'
+---
+

--- a/src/content/i-shipped/glitch.mdx
+++ b/src/content/i-shipped/glitch.mdx
@@ -1,0 +1,7 @@
+---
+summary: glitch
+repo: joeinnes/covid19-hungary
+mergeDate: 2020-07-22
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/grey-out-quickstarts-for-rn.mdx
+++ b/src/content/i-shipped/grey-out-quickstarts-for-rn.mdx
@@ -1,0 +1,11 @@
+---
+summary: grey out quickstarts for RN
+repo: garden-co/jazz
+mergeDate: 2025-10-22
+prNumber: '3088'
+---
+# Description
+Quickstarts are only available for React and Svelte. This PR greys them out in the nav until they're available for all frameworks
+
+## Manual testing instructions
+Switch to RN or Expo and check quickstarts are hidden.

--- a/src/content/i-shipped/hotfix-for-homepage.mdx
+++ b/src/content/i-shipped/hotfix-for-homepage.mdx
@@ -1,0 +1,17 @@
+---
+summary: hotfix for homepage
+repo: garden-co/jazz
+mergeDate: 2025-10-09
+prNumber: '3028'
+---
+# Description
+The added styling was causing overflow on basically every parent which contained a button.
+
+## Manual testing instructions
+Check and see there's no overflow any more
+
+Before:
+<img width="1667" height="2332" alt="image" src="https://github.com/user-attachments/assets/2dba2aa2-58b2-4cb8-9652-a0afa8e3f97c" />
+
+After:
+<img width="1661" height="5281" alt="image" src="https://github.

--- a/src/content/i-shipped/hover-styles-now-included.mdx
+++ b/src/content/i-shipped/hover-styles-now-included.mdx
@@ -1,0 +1,7 @@
+---
+summary: hover styles now included
+repo: joeinnes/homepage-src
+mergeDate: 2016-05-11
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/improve-showcase-display-on-smaller-screens.mdx
+++ b/src/content/i-shipped/improve-showcase-display-on-smaller-screens.mdx
@@ -1,0 +1,11 @@
+---
+summary: improve showcase display on smaller screens
+repo: garden-co/jazz
+mergeDate: 2025-12-09
+prNumber: '3257'
+---
+# Description
+Quick visual fix on the showcase to ensure the images and text are constrained to the size of the container for mobile display.
+
+## Manual testing instructions
+Check the 'showcase' page on mobile/responsive browser view.

--- a/src/content/i-shipped/increase-z-index-of-aoj-banner.mdx
+++ b/src/content/i-shipped/increase-z-index-of-aoj-banner.mdx
@@ -1,0 +1,23 @@
+---
+summary: increase Z-index of AoJ banner
+repo: garden-co/jazz
+mergeDate: 2025-12-01
+prNumber: '3229'
+---
+# Description
+There's some interference further down the page.
+
+## Manual testing instructions
+
+Scroll down and ensure banner overlays all elements
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a...

--- a/src/content/i-shipped/initial-set-up.mdx
+++ b/src/content/i-shipped/initial-set-up.mdx
@@ -1,0 +1,7 @@
+---
+summary: initial set-up
+repo: joeinnes/tastine-svelte
+mergeDate: 2023-03-26
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/joeinnesissue4.mdx
+++ b/src/content/i-shipped/joeinnesissue4.mdx
@@ -1,0 +1,7 @@
+---
+summary: joeinnes/issue4
+repo: joeinnes/notesvac
+mergeDate: 2022-01-13
+prNumber: '8'
+---
+

--- a/src/content/i-shipped/loaded-non-critical-styles.mdx
+++ b/src/content/i-shipped/loaded-non-critical-styles.mdx
@@ -1,0 +1,7 @@
+---
+summary: loaded non-critical styles
+repo: joeinnes/homepage-src
+mergeDate: 2016-05-11
+prNumber: '2'
+---
+

--- a/src/content/i-shipped/make-latency-bar-red-if-theres-an-ongoing-outage.mdx
+++ b/src/content/i-shipped/make-latency-bar-red-if-theres-an-ongoing-outage.mdx
@@ -1,0 +1,11 @@
+---
+summary: >-
+  make latency bar red if there's an ongoing outage
+repo: garden-co/jazz
+mergeDate: 2025-09-09
+prNumber: '2877'
+---
+# Description
+It was quite frustrating to see during today's outage a bright green latency indicator next to a 'down' indicator. This update cascades the `isUp` property down to the latency chart, and in case `isUp` is false, the last latency indicator will be red.
+
+Technically this is not accurate.

--- a/src/content/i-shipped/markdown-emoticons.mdx
+++ b/src/content/i-shipped/markdown-emoticons.mdx
@@ -1,0 +1,7 @@
+---
+summary: markdown emoticons
+repo: joeinnes/chat
+mergeDate: 2015-10-05
+prNumber: '5'
+---
+Merging markdown and emoticon support into dev

--- a/src/content/i-shipped/merge-in-initial.mdx
+++ b/src/content/i-shipped/merge-in-initial.mdx
@@ -1,0 +1,7 @@
+---
+summary: merge in initial
+repo: joeinnes/wedding-app
+mergeDate: 2019-10-13
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/merge-pull-request-5-from-joeinnesmarkdown-emoticons.mdx
+++ b/src/content/i-shipped/merge-pull-request-5-from-joeinnesmarkdown-emoticons.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  merge pull request #5 from joeinnes/markdown-emoticons
+repo: joeinnes/chat
+mergeDate: 2015-10-08
+prNumber: '7'
+---
+Markdown emoticons

--- a/src/content/i-shipped/merging-in-dev.mdx
+++ b/src/content/i-shipped/merging-in-dev.mdx
@@ -1,0 +1,7 @@
+---
+summary: merging in dev
+repo: joeinnes/chat
+mergeDate: 2015-10-03
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/message-permissions.mdx
+++ b/src/content/i-shipped/message-permissions.mdx
@@ -1,0 +1,7 @@
+---
+summary: message permissions
+repo: joeinnes/chat
+mergeDate: 2015-10-08
+prNumber: '6'
+---
+Merging on to dev.

--- a/src/content/i-shipped/minor-typo-fix.mdx
+++ b/src/content/i-shipped/minor-typo-fix.mdx
@@ -1,0 +1,7 @@
+---
+summary: minor typo fix
+repo: apostrophecms/apostrophe-documentation
+mergeDate: 2020-10-20
+prNumber: '317'
+---
+Typo fix

--- a/src/content/i-shipped/more-verbose-example.mdx
+++ b/src/content/i-shipped/more-verbose-example.mdx
@@ -1,0 +1,7 @@
+---
+summary: more verbose example
+repo: humaans/figbird
+mergeDate: 2020-08-03
+prNumber: '9'
+---
+Added feathers client configuration

--- a/src/content/i-shipped/move-codecs-under-schema-and-republish-link.mdx
+++ b/src/content/i-shipped/move-codecs-under-schema-and-republish-link.mdx
@@ -1,0 +1,22 @@
+---
+summary: move codecs under schema and republish link
+repo: garden-co/jazz
+mergeDate: 2025-11-04
+prNumber: '3137'
+---
+# Description
+Codecs doc got unlinked at some point, relinking and adding it under the schema section of the nav
+
+## Manual testing instructions
+Check under 'Schemas' for codecs in the nav.
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are...

--- a/src/content/i-shipped/notifications.mdx
+++ b/src/content/i-shipped/notifications.mdx
@@ -1,0 +1,7 @@
+---
+summary: notifications
+repo: joeinnes/chat
+mergeDate: 2016-03-13
+prNumber: '22'
+---
+

--- a/src/content/i-shipped/post-015-docs-fixes.mdx
+++ b/src/content/i-shipped/post-015-docs-fixes.mdx
@@ -1,0 +1,11 @@
+---
+summary: post 0.15 docs fixes
+repo: garden-co/jazz
+mergeDate: 2025-06-24
+prNumber: '2570'
+---
+Fixes a few minor docs issues:
+
+1. References to v0.14 being the most recent release removed
+2. Adds a warning that AccountSchema still needs to be passed to the provider (this part of the upgrade guide was misunderstood by quite a few people, myself included)
+3. Adds notes clarifying the requirement to use Node.js v20 in the installation guides for all frameworks and the create-jazz-app doc.

--- a/src/content/i-shipped/proofreadcopy-edited-readme.mdx
+++ b/src/content/i-shipped/proofreadcopy-edited-readme.mdx
@@ -1,0 +1,7 @@
+---
+summary: proofread/copy-edited README
+repo: dmitriytat/jedi-validate
+mergeDate: 2016-10-09
+prNumber: '7'
+---
+Closes #4

--- a/src/content/i-shipped/pushed-footer-to-bottom.mdx
+++ b/src/content/i-shipped/pushed-footer-to-bottom.mdx
@@ -1,0 +1,7 @@
+---
+summary: pushed footer to bottom
+repo: joeinnes/screen2vid
+mergeDate: 2019-10-28
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/query-in-url.mdx
+++ b/src/content/i-shipped/query-in-url.mdx
@@ -1,0 +1,11 @@
+---
+summary: query in url
+repo: waldyrious/primerpedia
+mergeDate: 2016-10-10
+prNumber: '21'
+---
+Use ?q=<search term>
+
+Other params are left alone, and no action is taken if no parameter is present.
+
+Works by putting the search term in the box and calling the search function.

--- a/src/content/i-shipped/remove-arrow-from-initialisation-instructions-for-safari-compatibility.mdx
+++ b/src/content/i-shipped/remove-arrow-from-initialisation-instructions-for-safari-compatibility.mdx
@@ -1,0 +1,8 @@
+---
+summary: remove arrow from initialisation instructions for Safari compatibility
+repo: soyuka/dpicker
+mergeDate: 2016-09-18
+prNumber: '24'
+---
+Safari doesn't support ES6 arrow functions yet, sadly.
+Closes #23

--- a/src/content/i-shipped/remove-await-from-create-calls-in-code-examples.mdx
+++ b/src/content/i-shipped/remove-await-from-create-calls-in-code-examples.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  remove `await` from `create` calls in code examples
+repo: garden-co/jazz
+mergeDate: 2026-02-13
+prNumber: '3456'
+---
+Fixes an error in the performance skill which wrongly implied that CoValue creation is async

--- a/src/content/i-shipped/remove-manuscriptsprosemirror-recreate-steps-and-replace-with-local.mdx
+++ b/src/content/i-shipped/remove-manuscriptsprosemirror-recreate-steps-and-replace-with-local.mdx
@@ -1,0 +1,14 @@
+---
+summary: >-
+  remove `@manuscripts/prosemirror-recreate-steps` and replace with local implementation
+repo: garden-co/jazz
+mergeDate: 2026-02-13
+prNumber: '3459'
+---
+### Problem
+
+The `@manuscripts/prosemirror-recreate-steps` package pulls in transitive dependencies with known vulnerabilities. The package is also unmaintained and provides significantly more functionality than we actually use.
+
+### Solution
+
+Replaced the external dependency with a local `recreateTransform` implementation that uses ProseMirror's built-in `Fragment.

--- a/src/content/i-shipped/remove-unnecessary-consolelog.mdx
+++ b/src/content/i-shipped/remove-unnecessary-consolelog.mdx
@@ -1,0 +1,7 @@
+---
+summary: remove unnecessary console.log
+repo: garden-co/jazz
+mergeDate: 2025-06-02
+prNumber: '2367'
+---
+

--- a/src/content/i-shipped/replace-delete-local-data-modal-with-a-reusable-component.mdx
+++ b/src/content/i-shipped/replace-delete-local-data-modal-with-a-reusable-component.mdx
@@ -1,0 +1,23 @@
+---
+summary: replace delete local data modal with a reusable component
+repo: garden-co/jazz
+mergeDate: 2025-09-10
+prNumber: '2897'
+---
+# Description
+Extracted into separate module per https://github.com/garden-co/jazz/pull/2884#discussion_r2333481247
+
+## Manual testing instructions
+
+No specific testing, just a refactor.
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected...

--- a/src/content/i-shipped/restructure-the-docs-following-the-nav-menu-updates.mdx
+++ b/src/content/i-shipped/restructure-the-docs-following-the-nav-menu-updates.mdx
@@ -1,0 +1,17 @@
+---
+summary: restructure the docs following the nav menu updates
+repo: garden-co/jazz
+mergeDate: 2025-10-20
+prNumber: '3071'
+---
+# Description
+Since the nav menu update, docs are out of position compared to their places in the nav menu. This PR:
+
+1. Moves docs to the new location
+2. Updates the URLs in the nav menu to ensure the correct mapping
+3. Updates internal links
+4. 301 redirects the previous links to their new location
+
+## Manual testing instructions
+
+I used https://www.npmjs.

--- a/src/content/i-shipped/sass-modules.mdx
+++ b/src/content/i-shipped/sass-modules.mdx
@@ -1,0 +1,7 @@
+---
+summary: sass modules
+repo: traist-web-services/traist
+mergeDate: 2021-01-18
+prNumber: '16'
+---
+Bring SASS Module goodness into the main branch

--- a/src/content/i-shipped/sdk-start-auth-refresh-job-when-constructor-is-initialised.mdx
+++ b/src/content/i-shipped/sdk-start-auth-refresh-job-when-constructor-is-initialised.mdx
@@ -1,0 +1,10 @@
+---
+summary: >-
+  sDK: Start auth refresh job when constructor is initialised
+repo: directus/directus
+mergeDate: 2021-11-22
+prNumber: '9777'
+---
+Ref https://github.com/directus/directus/discussions/9720#discussioncomment-1634470
+
+If autorefresh is enabled, then this will cause the SDK to refresh tokens whenever it's loaded. This fixes bug #9639 (discussion #9720)

--- a/src/content/i-shipped/serialize-secretseed-as-array-in-auth-header.mdx
+++ b/src/content/i-shipped/serialize-secretseed-as-array-in-auth-header.mdx
@@ -1,0 +1,8 @@
+---
+summary: serialize secretSeed as array in auth header
+repo: garden-co/jazz
+mergeDate: 2026-01-12
+prNumber: '3352'
+---
+# Description
+Secret Seeds are stored as Uint8Arrays which leads to them being serialised as objects not arrays. This fix ensures they are correctly serialised so that they can be restored on the client (e.g. for passphrase/passkey generation for a BetterAuth user).

--- a/src/content/i-shipped/set-encoding-as-utf-8-in-diff_match_patchphp.mdx
+++ b/src/content/i-shipped/set-encoding-as-utf-8-in-diff_match_patchphp.mdx
@@ -1,0 +1,7 @@
+---
+summary: set encoding as UTF-8 in diff_match_patch.php
+repo: Codiad/Codiad
+mergeDate: 2015-09-25
+prNumber: '862'
+---
+Hopefully this will close out #841 and #828 - adding the UTF-8 encoding string to the diff_match_patch.php lib.

--- a/src/content/i-shipped/shadcn.mdx
+++ b/src/content/i-shipped/shadcn.mdx
@@ -1,0 +1,7 @@
+---
+summary: shadcn
+repo: joeinnes/drinks
+mergeDate: 2024-07-12
+prNumber: '3'
+---
+

--- a/src/content/i-shipped/some-options-for-globalformplugin-cant-be-passed-through-useformscreenplugin.mdx
+++ b/src/content/i-shipped/some-options-for-globalformplugin-cant-be-passed-through-useformscreenplugin.mdx
@@ -1,0 +1,19 @@
+---
+summary: >-
+  some options for GlobalFormPlugin can't be passed through useFormScreenPlugin
+repo: tinacms/tinacms
+mergeDate: 2021-02-01
+prNumber: '1703'
+---
+Adds an optional second argument to 'useFormScreenPlugin' to allow an icon to be passed to GlobalFormPlugin when instantiating a new Form Screen.
+ 
+<!--
+
+Thank you for contributing to TinaCMS!
+
+Several things must happen for your PR to be merged:
+
+1. It must successfully build, test, and lint your branch
+1. It must pass the dangerjs script
+2. It must be up-to-date with master
+3.

--- a/src/content/i-shipped/subs.mdx
+++ b/src/content/i-shipped/subs.mdx
@@ -1,0 +1,7 @@
+---
+summary: subs
+repo: joeinnes/chat
+mergeDate: 2015-10-16
+prNumber: '17'
+---
+Closes #12

--- a/src/content/i-shipped/suggested-trick-for-pushing-menu-below-toolbar.mdx
+++ b/src/content/i-shipped/suggested-trick-for-pushing-menu-below-toolbar.mdx
@@ -1,0 +1,17 @@
+---
+summary: suggested trick for pushing menu below toolbar
+repo: tinacms/tinacms
+mergeDate: 2021-01-19
+prNumber: '1687'
+---
+<!--
+
+Thank you for contributing to TinaCMS!
+
+Several things must happen for your PR to be merged:
+
+1. It must successfully build, test, and lint your branch
+1. It must pass the dangerjs script
+2. It must be up-to-date with master
+3. It must be approved by at least 1 tinacms core member
+4.

--- a/src/content/i-shipped/sveltekit.mdx
+++ b/src/content/i-shipped/sveltekit.mdx
@@ -1,0 +1,7 @@
+---
+summary: sveltekit
+repo: joeinnes/elpea
+mergeDate: 2021-11-29
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/swap-out-single-quotes-for-backticks.mdx
+++ b/src/content/i-shipped/swap-out-single-quotes-for-backticks.mdx
@@ -1,0 +1,7 @@
+---
+summary: swap out single quotes for backticks
+repo: TimFoerster/octobercms-leaflet
+mergeDate: 2020-08-17
+prNumber: '3'
+---
+If you try to bind a pop-up with an apostrophe in, then it will cause an error and the map won't load. Switching to template literals fixes this. Although this is arguably not a safe way to do this, it is no worse than it currently is. (eg: you could write a 'popup' containing the text `'); alert('xss');var ignore = '` which would also allow XSS attacks.

--- a/src/content/i-shipped/update-chat-example-to-use-jazz-for-message-and-image-handling.mdx
+++ b/src/content/i-shipped/update-chat-example-to-use-jazz-for-message-and-image-handling.mdx
@@ -1,0 +1,23 @@
+---
+summary: update chat example to use $jazz for message and image handling
+repo: garden-co/jazz
+mergeDate: 2025-09-08
+prNumber: '2885'
+---
+# Description
+Fix chat example for Vue
+
+## Manual testing instructions
+Build and run the chat app
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: Example for Vue only
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR changes
+- [ ] I've generated a changeset, if a version bump is...

--- a/src/content/i-shipped/update-examples-to-use-environment-variable-for-api-key.mdx
+++ b/src/content/i-shipped/update-examples-to-use-environment-variable-for-api-key.mdx
@@ -1,0 +1,9 @@
+---
+summary: update examples to use environment variable for API key
+repo: garden-co/jazz
+mergeDate: 2025-09-12
+prNumber: '2892'
+---
+- Added instructions to create a `.env` file and set `VITE_JAZZ_API_KEY` in multiple example README files.
+- Updated API key exports in example source files to use `import.meta.env.VITE_JAZZ_API_KEY` instead of hardcoded values.
+- Ensured consistency across all examples for API key configuration.

--- a/src/content/i-shipped/update-querying_mongodbmd.mdx
+++ b/src/content/i-shipped/update-querying_mongodbmd.mdx
@@ -1,0 +1,7 @@
+---
+summary: update querying_mongodb.md
+repo: getredash/website
+mergeDate: 2016-12-19
+prNumber: '17'
+---
+Added an example of filtering a Mongo query

--- a/src/content/i-shipped/update-readme-and-gitignore-files.mdx
+++ b/src/content/i-shipped/update-readme-and-gitignore-files.mdx
@@ -1,0 +1,11 @@
+---
+summary: update README and .gitignore files
+repo: garden-co/jazz
+mergeDate: 2025-06-12
+prNumber: '2513'
+---
+* Added instructions for renaming `.env.example` to `.env` in multiple README files.
+* Updated `.gitignore` files to include `.env` and `.env.*` while excluding `.env.example` and `.env.test`.
+* Removed `.env` file from `examples/multi-cursors`.
+* Improved consistency across example projects.
+Fixes #2371

--- a/src/content/i-shipped/update-readme-files-to-reflect-changes-in-local-sync-server-setup.mdx
+++ b/src/content/i-shipped/update-readme-files-to-reflect-changes-in-local-sync-server-setup.mdx
@@ -1,0 +1,10 @@
+---
+summary: update README files to reflect changes in local sync server setup
+repo: garden-co/jazz
+mergeDate: 2025-06-05
+prNumber: '2444'
+---
+- Changed instructions for running a local sync server to use `sync` parameter format: `{ peer: "ws://localhost:4200" }`.
+- Updated multiple example README files for consistency across projects.
+
+Closes #2424

--- a/src/content/i-shipped/update-readmemd-2.mdx
+++ b/src/content/i-shipped/update-readmemd-2.mdx
@@ -1,0 +1,7 @@
+---
+summary: update README.md
+repo: joeinnes/simon-says
+mergeDate: 2020-10-01
+prNumber: '4'
+---
+

--- a/src/content/i-shipped/update-readmemd-3.mdx
+++ b/src/content/i-shipped/update-readmemd-3.mdx
@@ -1,0 +1,7 @@
+---
+summary: update README.md
+repo: joeinnes/simon-says
+mergeDate: 2020-10-01
+prNumber: '3'
+---
+

--- a/src/content/i-shipped/update-readmemd-4.mdx
+++ b/src/content/i-shipped/update-readmemd-4.mdx
@@ -1,0 +1,7 @@
+---
+summary: update README.md
+repo: joeinnes/simon-says
+mergeDate: 2020-10-01
+prNumber: '2'
+---
+

--- a/src/content/i-shipped/update-readmemd-5.mdx
+++ b/src/content/i-shipped/update-readmemd-5.mdx
@@ -1,0 +1,7 @@
+---
+summary: update README.md
+repo: joeinnes/simon-says
+mergeDate: 2020-10-01
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/update-readmemd.mdx
+++ b/src/content/i-shipped/update-readmemd.mdx
@@ -1,0 +1,7 @@
+---
+summary: update README.md
+repo: joeinnes/sk-blog
+mergeDate: 2022-10-28
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/update-svelte-starter.mdx
+++ b/src/content/i-shipped/update-svelte-starter.mdx
@@ -1,0 +1,21 @@
+---
+summary: update Svelte starter
+repo: garden-co/jazz
+mergeDate: 2025-09-12
+prNumber: '2913'
+---
+# Description
+Fix for #2892—Svelte starter won't run unless a `.env` file is present with the variable due to the way SvelteKit imports the variable.
+
+## Manual testing instructions
+N/A
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [ ] Tests have not been updated, because: N/A
+- [ ] I need help with writing tests
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected...

--- a/src/content/i-shipped/update-svelte-testing-path-in-packagejson.mdx
+++ b/src/content/i-shipped/update-svelte-testing-path-in-packagejson.mdx
@@ -1,0 +1,24 @@
+---
+summary: update Svelte testing path in package.json
+repo: garden-co/jazz
+mergeDate: 2025-08-25
+prNumber: '2810'
+---
+# Description
+
+Fixes  #2809 
+
+## Manual testing instructions
+
+Create a Svelte App, install Vitest, check that imports from `jazz-tools/svelte/testing` work properly.
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: corrects a typo
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR...

--- a/src/content/i-shipped/update-to-newest-version-of-nextjs.mdx
+++ b/src/content/i-shipped/update-to-newest-version-of-nextjs.mdx
@@ -1,0 +1,7 @@
+---
+summary: update to newest version of next.js
+repo: traist-web-services/elpea
+mergeDate: 2021-10-11
+prNumber: '7'
+---
+

--- a/src/content/i-shipped/update-useframework-to-respond-to-tab_change_events-emitted-on-the-window.mdx
+++ b/src/content/i-shipped/update-useframework-to-respond-to-tab_change_events-emitted-on-the-window.mdx
@@ -1,0 +1,11 @@
+---
+summary: >-
+  update `useFramework` to respond to TAB_CHANGE_EVENTs emitted on the window
+repo: garden-co/jazz
+mergeDate: 2025-09-18
+prNumber: '2933'
+---
+# Description
+The `TabbedCodeGroup` component emits custom events on the window when the user changes framework to allow all parts of the docs to update.
+
+However, the `useFramework` hook which feeds the current framework to the `ContentByFramework` component wasn't listening to these changes, so the content contained within was stuck at whatever it was when the page was first loaded.

--- a/src/content/i-shipped/updated-app.mdx
+++ b/src/content/i-shipped/updated-app.mdx
@@ -1,0 +1,7 @@
+---
+summary: updated app
+repo: joeinnes/bubi-bikes
+mergeDate: 2020-03-15
+prNumber: '2'
+---
+

--- a/src/content/i-shipped/updated-with-glitch-2.mdx
+++ b/src/content/i-shipped/updated-with-glitch-2.mdx
@@ -1,0 +1,7 @@
+---
+summary: updated with Glitch
+repo: joeinnes/save-the-date
+mergeDate: 2019-12-30
+prNumber: '5'
+---
+

--- a/src/content/i-shipped/updated-with-glitch-3.mdx
+++ b/src/content/i-shipped/updated-with-glitch-3.mdx
@@ -1,0 +1,7 @@
+---
+summary: updated with Glitch
+repo: joeinnes/save-the-date
+mergeDate: 2019-12-26
+prNumber: '4'
+---
+

--- a/src/content/i-shipped/updated-with-glitch-4.mdx
+++ b/src/content/i-shipped/updated-with-glitch-4.mdx
@@ -1,0 +1,7 @@
+---
+summary: updated with Glitch
+repo: joeinnes/save-the-date
+mergeDate: 2019-12-26
+prNumber: '3'
+---
+

--- a/src/content/i-shipped/updated-with-glitch-5.mdx
+++ b/src/content/i-shipped/updated-with-glitch-5.mdx
@@ -1,0 +1,7 @@
+---
+summary: updated with Glitch
+repo: joeinnes/save-the-date
+mergeDate: 2019-12-25
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/updated-with-glitch.mdx
+++ b/src/content/i-shipped/updated-with-glitch.mdx
@@ -1,0 +1,7 @@
+---
+summary: updated with Glitch
+repo: joeinnes/save-the-date
+mergeDate: 2020-01-12
+prNumber: '6'
+---
+

--- a/src/content/i-shipped/updating-dev.mdx
+++ b/src/content/i-shipped/updating-dev.mdx
@@ -1,0 +1,7 @@
+---
+summary: updating Dev
+repo: joeinnes/chat
+mergeDate: 2015-10-16
+prNumber: '19'
+---
+

--- a/src/content/i-shipped/use-hash-fragment-in-invite-url-example.mdx
+++ b/src/content/i-shipped/use-hash-fragment-in-invite-url-example.mdx
@@ -1,0 +1,22 @@
+---
+summary: use hash fragment in invite URL example
+repo: garden-co/jazz
+mergeDate: 2025-12-12
+prNumber: '3258'
+---
+# Description
+Tiny PR based on @ammmir's comments
+
+## Manual testing instructions
+Check the permissions and sharings to see the correct illustrated example of an invite link.
+
+## Tests
+
+- [ ] Tests have been added and/or updated
+- [x] Tests have not been updated, because: Docs
+- [ ] I need help with writing tests
+
+
+## Checklist
+
+- [ ] I've updated the part of the docs that are affected the PR...

--- a/src/content/i-shipped/using-exif-data-for-file-names-will-give-more-accuracy.mdx
+++ b/src/content/i-shipped/using-exif-data-for-file-names-will-give-more-accuracy.mdx
@@ -1,0 +1,7 @@
+---
+summary: using EXIF data for file names will give more accuracy
+repo: joeinnes/innes-family-photos
+mergeDate: 2022-08-13
+prNumber: '1'
+---
+

--- a/src/content/i-shipped/zug.mdx
+++ b/src/content/i-shipped/zug.mdx
@@ -1,0 +1,7 @@
+---
+summary: zug
+repo: joeinnes/sk-blog
+mergeDate: 2022-10-28
+prNumber: '2'
+---
+


### PR DESCRIPTION
Added i-shipped entries for all merged PRs on public repos that didn't
already have entries, spanning contributions from 2015-2026 across repos
including garden-co/jazz, zed-industries/zed, directus/directus,
vercel/workflow, tinacms/tinacms, and many others. Also fixed the repo
field in first-class-svelte-support-for-better-auth.mdx (was '3285',
should be 'garden-co/jazz').

https://claude.ai/code/session_01VDF179yyMRfhxUKRNT6c77