### PR TITLE
Add teal.fm recent tracks to now page

### DIFF
--- a/src/components/RecentTracks.svelte
+++ b/src/components/RecentTracks.svelte
@@ -4,25 +4,33 @@
 	const HANDLE = 'joeinn.es';
 	const COLLECTION = 'fm.teal.alpha.feed.play';
 	const PDS = 'https://bsky.social';
+	const COVER_ART_BASE = 'https://coverartarchive.org/release';
 
-	let tracks = $state([]);
+	let allTracks = $state([]);
 	let loading = $state(true);
 	let error = $state('');
+	let selectedPeriod = $state('week');
+	let selectedCategory = $state('albums');
 
 	onMount(async () => {
 		try {
-			const params = new URLSearchParams({
-				repo: HANDLE,
-				collection: COLLECTION,
-				limit: '3',
-				reverse: 'true',
-			});
-			const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
-			if (!res.ok) {
-				throw new Error(`Failed to fetch tracks (${res.status})`);
-			}
-			const data = await res.json();
-			tracks = data.records.map((r) => r.value);
+			let cursor;
+			const records = [];
+			do {
+				const params = new URLSearchParams({
+					repo: HANDLE,
+					collection: COLLECTION,
+					limit: '100',
+					reverse: 'true',
+				});
+				if (cursor) params.set('cursor', cursor);
+				const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
+				if (!res.ok) throw new Error(`Failed to fetch tracks (${res.status})`);
+				const data = await res.json();
+				records.push(...data.records.map((r) => r.value));
+				cursor = data.cursor;
+			} while (cursor);
+			allTracks = records;
 		} catch (e) {
 			error = e.message;
 		} finally {
@@ -30,21 +38,55 @@
 		}
 	});
 
-	function artistNames(track) {
-		if (track.artists?.length) {
-			return track.artists.map((a) => a.artistName).join(', ');
-		}
-		if (track.artistNames?.length) {
-			return track.artistNames.join(', ');
-		}
+	function getArtistNames(track) {
+		if (track.artists?.length) return track.artists.map((a) => a.artistName).join(', ');
+		if (track.artistNames?.length) return track.artistNames.join(', ');
 		return 'Unknown Artist';
+	}
+
+	function coverUrl(releaseMbId) {
+		if (!releaseMbId) return null;
+		return `${COVER_ART_BASE}/${releaseMbId}/front-250`;
+	}
+
+	function filterByPeriod(tracks, period) {
+		if (period === 'all') return tracks;
+		const ms = { week: 7, month: 30, year: 365 };
+		const cutoff = Date.now() - (ms[period] ?? 7) * 86400000;
+		return tracks.filter((t) => t.playedTime && new Date(t.playedTime).getTime() >= cutoff);
+	}
+
+	function aggregateBy(tracks, category) {
+		const map = new Map();
+		for (const track of tracks) {
+			const artist = getArtistNames(track);
+			let key, name, subtitle;
+			if (category === 'artists') {
+				key = artist;
+				name = artist;
+				subtitle = '';
+			} else if (category === 'albums') {
+				name = track.releaseName || 'Unknown Album';
+				key = track.releaseMbId || `${name}::${artist}`;
+				subtitle = artist;
+			} else {
+				name = track.trackName;
+				key = track.recordingMbId || `${name}::${artist}`;
+				subtitle = artist;
+			}
+			if (!map.has(key)) {
+				map.set(key, { name, subtitle, mbId: track.releaseMbId, count: 0 });
+			}
+			const entry = map.get(key);
+			entry.count++;
+			if (!entry.mbId && track.releaseMbId) entry.mbId = track.releaseMbId;
+		}
+		return [...map.values()].sort((a, b) => b.count - a.count);
 	}
 
 	function relativeTime(dateStr) {
 		if (!dateStr) return '';
-		const now = Date.now();
-		const then = new Date(dateStr).getTime();
-		const diffMs = now - then;
+		const diffMs = Date.now() - new Date(dateStr).getTime();
 		const diffMins = Math.floor(diffMs / 60000);
 		if (diffMins < 1) return 'just now';
 		if (diffMins < 60) return `${diffMins}m ago`;
@@ -55,71 +97,315 @@
 		if (diffDays < 7) return `${diffDays}d ago`;
 		return new Date(dateStr).toLocaleDateString();
 	}
+
+	function handleImgError(e) {
+		e.currentTarget.style.display = 'none';
+	}
+
+	let recentTracks = $derived(allTracks.slice(0, 3));
+
+	let weeklyAlbums = $derived.by(() => {
+		const weekTracks = filterByPeriod(allTracks, 'week');
+		const seen = new Set();
+		const albums = [];
+		for (const track of weekTracks) {
+			const key = track.releaseMbId || `${track.releaseName}::${getArtistNames(track)}`;
+			if (!track.releaseName || seen.has(key)) continue;
+			seen.add(key);
+			albums.push({
+				name: track.releaseName,
+				artist: getArtistNames(track),
+				mbId: track.releaseMbId,
+			});
+		}
+		return albums.slice(0, 16);
+	});
+
+	let filteredTracks = $derived(filterByPeriod(allTracks, selectedPeriod));
+	let stats = $derived(aggregateBy(filteredTracks, selectedCategory).slice(0, 10));
+
+	const periods = [
+		{ id: 'week', label: 'This Week' },
+		{ id: 'month', label: 'This Month' },
+		{ id: 'year', label: 'This Year' },
+		{ id: 'all', label: 'All Time' },
+	];
+
+	const categories = [
+		{ id: 'artists', label: 'Artists' },
+		{ id: 'albums', label: 'Albums' },
+		{ id: 'tracks', label: 'Tracks' },
+	];
 </script>
 
 {#if loading}
-	<p>Loading recent tracks...</p>
+	<p>Loading listening data...</p>
 {:else if error}
-	<p>Could not load recent tracks.</p>
-{:else if tracks.length === 0}
-	<p>No recent tracks found.</p>
+	<p>Could not load listening data.</p>
 {:else}
-	<ol class="track-list">
-		{#each tracks as track}
-			<li class="track">
-				<span class="track-name">{track.trackName}</span>
-				<span class="track-artist">{artistNames(track)}</span>
-				{#if track.releaseName}
-					<span class="track-release">{track.releaseName}</span>
-				{/if}
-				{#if track.playedTime}
-					<time class="track-time" datetime={track.playedTime}>{relativeTime(track.playedTime)}</time>
-				{/if}
-			</li>
+	{#if recentTracks.length > 0}
+		<h3>Recently Played</h3>
+		<ol class="recent-list">
+			{#each recentTracks as track}
+				<li class="recent-track">
+					<div class="recent-info">
+						<span class="name">{track.trackName}</span>
+						<span class="artist">{getArtistNames(track)}</span>
+						{#if track.releaseName}
+							<span class="release">{track.releaseName}</span>
+						{/if}
+					</div>
+					{#if track.playedTime}
+						<time class="time" datetime={track.playedTime}>{relativeTime(track.playedTime)}</time>
+					{/if}
+				</li>
+			{/each}
+		</ol>
+	{/if}
+
+	{#if weeklyAlbums.length > 0}
+		<h3>This Week's Albums</h3>
+		<div class="mosaic">
+			{#each weeklyAlbums as album}
+				<div class="mosaic-cell" title="{album.name} — {album.artist}">
+					{#if album.mbId}
+						<img
+							src={coverUrl(album.mbId)}
+							alt="{album.name} by {album.artist}"
+							loading="lazy"
+							onerror={handleImgError}
+						/>
+					{/if}
+					<div class="mosaic-fallback">
+						<span>{album.name}</span>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<h3>Stats</h3>
+	<div class="tab-row">
+		{#each periods as period}
+			<button
+				class="tab"
+				class:active={selectedPeriod === period.id}
+				onclick={() => (selectedPeriod = period.id)}
+			>{period.label}</button>
 		{/each}
-	</ol>
-	<p class="track-attribution">
+	</div>
+	<div class="tab-row">
+		{#each categories as cat}
+			<button
+				class="tab"
+				class:active={selectedCategory === cat.id}
+				onclick={() => (selectedCategory = cat.id)}
+			>{cat.label}</button>
+		{/each}
+	</div>
+
+	{#if stats.length > 0}
+		<ol class="stats-list">
+			{#each stats as item}
+				<li class="stat-item">
+					<div class="stat-cover">
+						{#if item.mbId}
+							<img
+								src={coverUrl(item.mbId)}
+								alt={item.name}
+								loading="lazy"
+								onerror={handleImgError}
+							/>
+						{/if}
+						<div class="stat-cover-fallback">{item.name[0]}</div>
+					</div>
+					<div class="stat-info">
+						<span class="name">{item.name}</span>
+						{#if item.subtitle}
+							<span class="artist">{item.subtitle}</span>
+						{/if}
+						<span class="stat-count">{item.count} {item.count === 1 ? 'play' : 'plays'}</span>
+					</div>
+				</li>
+			{/each}
+		</ol>
+	{:else}
+		<p>No listening data for this period.</p>
+	{/if}
+
+	<p class="attribution">
 		Tracked with <a href="https://teal.fm" target="_blank" rel="noopener">teal.fm</a>, stored on the <a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
 	</p>
 {/if}
 
 <style>
-	.track-list {
+	/* Recent tracks */
+	.recent-list {
 		list-style: none;
 		padding: 0;
 		display: flex;
 		flex-direction: column;
 		gap: var(--inline-spacing);
 	}
-
-	.track {
+	.recent-list * {
+		padding-block-start: 0;
+	}
+	.recent-track {
 		display: flex;
-		flex-direction: column;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: calc(var(--inline-spacing) * 2);
 		padding: calc(var(--inline-spacing) * 2);
 		border-radius: var(--border-radius);
-		background-color: color-mix(in hsl, var(--foreground) 5%, var(--background) 95%);
+		background: color-mix(in hsl, var(--foreground) 5%, var(--background) 95%);
 	}
-
-	.track-name {
+	.recent-info {
+		display: flex;
+		flex-direction: column;
+	}
+	.name {
 		font-weight: 700;
 	}
-
-	.track-artist {
+	.artist {
 		color: var(--primary);
 	}
-
-	.track-release {
+	.release {
 		color: var(--muted);
 		font-size: 0.85em;
 	}
+	.time {
+		color: var(--muted);
+		font-size: 0.75em;
+		font-family: var(--font-mono);
+		white-space: nowrap;
+	}
 
-	.track-time {
+	/* Album mosaic */
+	.mosaic {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 2px;
+	}
+	.mosaic * {
+		padding-block-start: 0;
+	}
+	.mosaic-cell {
+		position: relative;
+		aspect-ratio: 1;
+		overflow: hidden;
+		background: color-mix(in hsl, var(--foreground) 10%, var(--background) 90%);
+	}
+	.mosaic-cell img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		z-index: 1;
+	}
+	.mosaic-fallback {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.25em;
+		font-size: 0.6em;
+		text-align: center;
+		color: var(--muted);
+		word-break: break-word;
+		line-height: 1.2;
+	}
+
+	/* Tabs */
+	.tab-row {
+		display: flex;
+		gap: var(--inline-spacing);
+		flex-wrap: wrap;
+	}
+	.tab-row * {
+		padding-block-start: 0;
+	}
+	.tab {
+		background: transparent;
+		color: var(--muted);
+		padding: var(--inline-spacing) calc(var(--inline-spacing) * 2);
+		border: 1px solid var(--very-muted);
+		border-radius: var(--border-radius);
+		cursor: pointer;
+		font-size: 0.75em;
+	}
+	.tab:hover {
+		color: var(--foreground);
+		border-color: var(--foreground);
+	}
+	.tab.active {
+		background: var(--primary);
+		color: #fff;
+		border-color: var(--primary);
+	}
+
+	/* Stats list */
+	.stats-list {
+		list-style: none;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--inline-spacing);
+	}
+	.stats-list * {
+		padding-block-start: 0;
+	}
+	.stat-item {
+		display: flex;
+		align-items: center;
+		gap: calc(var(--inline-spacing) * 2);
+	}
+	.stat-cover {
+		position: relative;
+		width: 3em;
+		height: 3em;
+		flex-shrink: 0;
+		border-radius: var(--border-radius);
+		overflow: hidden;
+		background: color-mix(in hsl, var(--foreground) 10%, var(--background) 90%);
+	}
+	.stat-cover img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		z-index: 1;
+	}
+	.stat-cover-fallback {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 700;
+		font-size: 1.2em;
+		color: var(--muted);
+	}
+	.stat-info {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+	.stat-info .name,
+	.stat-info .artist {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.stat-count {
 		color: var(--muted);
 		font-size: 0.75em;
 		font-family: var(--font-mono);
 	}
 
-	.track-attribution {
+	.attribution {
 		font-size: 0.75em;
 		color: var(--muted);
 	}

--- a/src/components/RecentTracks.svelte
+++ b/src/components/RecentTracks.svelte
@@ -1,0 +1,126 @@
+<script>
+	import { onMount } from 'svelte';
+
+	const HANDLE = 'joeinn.es';
+	const COLLECTION = 'fm.teal.alpha.feed.play';
+	const PDS = 'https://bsky.social';
+
+	let tracks = $state([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		try {
+			const params = new URLSearchParams({
+				repo: HANDLE,
+				collection: COLLECTION,
+				limit: '3',
+				reverse: 'true',
+			});
+			const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
+			if (!res.ok) {
+				throw new Error(`Failed to fetch tracks (${res.status})`);
+			}
+			const data = await res.json();
+			tracks = data.records.map((r) => r.value);
+		} catch (e) {
+			error = e.message;
+		} finally {
+			loading = false;
+		}
+	});
+
+	function artistNames(track) {
+		if (track.artists?.length) {
+			return track.artists.map((a) => a.artistName).join(', ');
+		}
+		if (track.artistNames?.length) {
+			return track.artistNames.join(', ');
+		}
+		return 'Unknown Artist';
+	}
+
+	function relativeTime(dateStr) {
+		if (!dateStr) return '';
+		const now = Date.now();
+		const then = new Date(dateStr).getTime();
+		const diffMs = now - then;
+		const diffMins = Math.floor(diffMs / 60000);
+		if (diffMins < 1) return 'just now';
+		if (diffMins < 60) return `${diffMins}m ago`;
+		const diffHours = Math.floor(diffMins / 60);
+		if (diffHours < 24) return `${diffHours}h ago`;
+		const diffDays = Math.floor(diffHours / 24);
+		if (diffDays === 1) return 'yesterday';
+		if (diffDays < 7) return `${diffDays}d ago`;
+		return new Date(dateStr).toLocaleDateString();
+	}
+</script>
+
+{#if loading}
+	<p>Loading recent tracks...</p>
+{:else if error}
+	<p>Could not load recent tracks.</p>
+{:else if tracks.length === 0}
+	<p>No recent tracks found.</p>
+{:else}
+	<ol class="track-list">
+		{#each tracks as track}
+			<li class="track">
+				<span class="track-name">{track.trackName}</span>
+				<span class="track-artist">{artistNames(track)}</span>
+				{#if track.releaseName}
+					<span class="track-release">{track.releaseName}</span>
+				{/if}
+				{#if track.playedTime}
+					<time class="track-time" datetime={track.playedTime}>{relativeTime(track.playedTime)}</time>
+				{/if}
+			</li>
+		{/each}
+	</ol>
+	<p class="track-attribution">
+		Tracked with <a href="https://teal.fm" target="_blank" rel="noopener">teal.fm</a>, stored on the <a href="https://atproto.com" target="_blank" rel="noopener">AT Protocol</a>.
+	</p>
+{/if}
+
+<style>
+	.track-list {
+		list-style: none;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--inline-spacing);
+	}
+
+	.track {
+		display: flex;
+		flex-direction: column;
+		padding: calc(var(--inline-spacing) * 2);
+		border-radius: var(--border-radius);
+		background-color: color-mix(in hsl, var(--foreground) 5%, var(--background) 95%);
+	}
+
+	.track-name {
+		font-weight: 700;
+	}
+
+	.track-artist {
+		color: var(--primary);
+	}
+
+	.track-release {
+		color: var(--muted);
+		font-size: 0.85em;
+	}
+
+	.track-time {
+		color: var(--muted);
+		font-size: 0.75em;
+		font-family: var(--font-mono);
+	}
+
+	.track-attribution {
+		font-size: 0.75em;
+		color: var(--muted);
+	}
+</style>

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -8,7 +8,7 @@ const reader = createReader(process.cwd(), keystaticConfig);
 const now = await reader.singletons.now.read();
 const content = await now?.now();
 const renderedMd = await marked.parse(content || "");
-import WeekInMusic from "../../components/MyMusic.astro";
+import RecentTracks from "../../components/RecentTracks.svelte";
 ---
 
 <Layout title="Joe Innes | Now">
@@ -18,16 +18,7 @@ import WeekInMusic from "../../components/MyMusic.astro";
     <article set:html={renderedMd} />
     <article>
       <h2>Listening To...</h2>
-
-      <img
-        src="https://www.tapmusic.net/collage.php?user=Mangula_D1S&type=7day&size=4x4"
-        alt="Weekly Music Collage"
-      />
-
-      <p>
-        Note: this was generated automatically based on the top tracks I
-        listened to over last week.
-      </p>
+      <RecentTracks client:load />
     </article>
   </main>
 </Layout>


### PR DESCRIPTION
Replace the static Last.fm collage with a dynamic Svelte component
that fetches the last 3 played tracks from the AT Protocol via
the fm.teal.alpha.feed.play collection. Data is loaded client-side
so it's always fresh.

https://claude.ai/code/session_01FdHvFoToAKAjCEnzWgUJnM