### PR TITLE
Add 8 new i-shipped entries for garden-co/jazz2 PRs #637, #661–#695

### DIFF
--- a/src/content/i-shipped/a-fix-for-startup-and-auth-issues-in-several-example-apps.mdx
+++ b/src/content/i-shipped/a-fix-for-startup-and-auth-issues-in-several-example-apps.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for startup and auth issues in several example apps
+repo: garden-co/jazz2
+mergeDate: 2026-04-27
+prNumber: '637'
+---
+I fixed broken configuration and authentication in several of Jazz's example applications. The affected apps — including WorkOS auth, Better Auth, Next.js CSR/SSR, Cloudflare Workers, and managed runtime — had issues that stopped developers from using them as working references.

--- a/src/content/i-shipped/a-fix-for-the-sveltekit-dev-plugin-failing-to-apply-config-on-cold-start.mdx
+++ b/src/content/i-shipped/a-fix-for-the-sveltekit-dev-plugin-failing-to-apply-config-on-cold-start.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for the SvelteKit dev plugin failing to apply config on cold start
+repo: garden-co/jazz2
+mergeDate: 2026-04-27
+prNumber: '671'
+---
+I fixed a bug where Jazz's SvelteKit plugin didn't apply its configuration correctly the very first time you started the dev server. The plugin now restarts Vite once after allocating the app ID, so SvelteKit's server hooks pick up the config properly.

--- a/src/content/i-shipped/a-fix-to-wait-for-membership-confirmation-before-enabling-the-chat-composer.mdx
+++ b/src/content/i-shipped/a-fix-to-wait-for-membership-confirmation-before-enabling-the-chat-composer.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix to wait for membership confirmation before enabling the chat composer
+repo: garden-co/jazz2
+mergeDate: 2026-04-27
+prNumber: '662'
+---
+I fixed a race condition in the React chat example where the message input would become usable before the server had confirmed the user was a member of the chat room. I added a readiness check to prevent this, and wrote a Playwright end-to-end test to guard against it happening again.

--- a/src/content/i-shipped/a-reorganisation-of-recipe-docs-and-a-new-group-permissions-recipe.mdx
+++ b/src/content/i-shipped/a-reorganisation-of-recipe-docs-and-a-new-group-permissions-recipe.mdx
@@ -1,0 +1,7 @@
+---
+summary: a reorganisation of recipe docs and a new group permissions recipe
+repo: garden-co/jazz2
+mergeDate: 2026-04-27
+prNumber: '668'
+---
+I reorganised Jazz's "recipes" (short how-to guides) into clearer sub-folders — access control, auth, and data patterns — so they're easier to find. I also added a new recipe showing how to configure group-level permissions for shared data.

--- a/src/content/i-shipped/deduplication-of-identical-permissions-bundle-publishes.mdx
+++ b/src/content/i-shipped/deduplication-of-identical-permissions-bundle-publishes.mdx
@@ -1,0 +1,7 @@
+---
+summary: deduplication of identical permissions bundle publishes
+repo: garden-co/jazz2
+mergeDate: 2026-04-28
+prNumber: '695'
+---
+I added content-based deduplication to the permissions bundle publishing step. When you deploy without changing your schema's access rules, the system now detects that the new bundle is identical to the current one and skips creating a new version — preventing unnecessary version bumps.

--- a/src/content/i-shipped/expanded-scaffold-test-coverage-to-all-self-hosted-starters.mdx
+++ b/src/content/i-shipped/expanded-scaffold-test-coverage-to-all-self-hosted-starters.mdx
@@ -1,0 +1,7 @@
+---
+summary: expanded scaffold test coverage to all self-hosted starters
+repo: garden-co/jazz2
+mergeDate: 2026-04-27
+prNumber: '661'
+---
+I extended our automated tests to cover three starter templates that previously had no test coverage. The tests check that the scaffolding tool creates the right files and structure, so we can catch regressions before they reach developers.

--- a/src/content/i-shipped/fallback-support-for-framework-prefixed-environment-variables-in-the-jazz-cli.mdx
+++ b/src/content/i-shipped/fallback-support-for-framework-prefixed-environment-variables-in-the-jazz-cli.mdx
@@ -1,0 +1,7 @@
+---
+summary: fallback support for framework-prefixed environment variables in the Jazz CLI
+repo: garden-co/jazz2
+mergeDate: 2026-04-27
+prNumber: '669'
+---
+I updated the Jazz command-line tool to recognise environment variables with framework-specific prefixes — like `VITE_`, `NEXT_PUBLIC_`, `PUBLIC_`, and `EXPO_PUBLIC_`. Previously, if you set your app ID using your framework's conventional prefix, the CLI wouldn't find it; now it checks all common prefixes automatically.

--- a/src/content/i-shipped/support-for-getter-functions-in-svelte-querysubscription.mdx
+++ b/src/content/i-shipped/support-for-getter-functions-in-svelte-querysubscription.mdx
@@ -1,0 +1,7 @@
+---
+summary: support for getter functions in Svelte QuerySubscription
+repo: garden-co/jazz2
+mergeDate: 2026-04-27
+prNumber: '672'
+---
+I updated Jazz's Svelte query API to accept getter functions — functions that return a query — in addition to plain query objects. This means reactive query updates now flow through automatically, matching what was already possible in the Vue integration.


### PR DESCRIPTION
Adds 8 new i-shipped entries for `garden-co/jazz2` merged PRs from 2026-04-27 and 2026-04-28:

- #637: fix example startup and auth issues
- #661: expand scaffold test coverage to all self-hosted starters
- #662: await membership confirmation before enabling chat composer
- #668: reorganise recipes and add group permissions recipe
- #669: fallback support for framework-prefixed env vars in CLI
- #671: SvelteKit dev plugin cold-start config fix
- #672: accept getter functions in Svelte QuerySubscription
- #695: deduplication of identical permissions bundle publishes

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHAULvSEY1iavWocg5Ax3m)_