### PR TITLE
Add 6 new i-shipped entries for garden-co/jazz2 PRs #706-716

### DIFF
--- a/src/content/i-shipped/a-fix-for-rows-vanishing-after-schema-migrations.mdx
+++ b/src/content/i-shipped/a-fix-for-rows-vanishing-after-schema-migrations.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for rows vanishing after schema migrations
+repo: garden-co/jazz2
+mergeDate: 2026-04-29
+prNumber: '707'
+---
+When you change your database schema (a "migration"), existing data should stay visible under the new schema. There was a bug where rows that existed before a migration would silently disappear — the resolved table name wasn't being carried through to the query engine, causing a "table not found" error that just dropped the rows silently. I fixed this by making sure the resolved table name is passed all the way through the schema-aware query path.

--- a/src/content/i-shipped/a-fix-for-sign-up-failing-on-react-native-after-a-local-first-session.mdx
+++ b/src/content/i-shipped/a-fix-for-sign-up-failing-on-react-native-after-a-local-first-session.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for sign-up failing on React Native after a local-first session
+repo: garden-co/jazz2
+mergeDate: 2026-04-30
+prNumber: '716'
+---
+Jazz lets users start as anonymous "local-first" users and later upgrade to a full account. On React Native, this upgrade was broken with the error "Sign up requires an active Jazz session" because the identity proof method was trying to use a WebAssembly module — which React Native doesn't support. I overrode the method in the React Native implementation to use the native `mintLocalFirstToken` function from `jazz-rn` instead, making the upgrade flow work on iOS and Android.

--- a/src/content/i-shipped/a-fix-for-the-expo-fetch-polyfill-rejecting-url-and-request-objects.mdx
+++ b/src/content/i-shipped/a-fix-for-the-expo-fetch-polyfill-rejecting-url-and-request-objects.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for the Expo fetch polyfill rejecting URL and Request objects
+repo: garden-co/jazz2
+mergeDate: 2026-04-29
+prNumber: '714'
+---
+On Expo (React Native), Jazz uses a custom `fetch` wrapper that bridges web-style network calls to the native layer. The web `fetch` standard allows passing a `URL` or `Request` object as input, but the native bridge only accepts plain strings — so libraries like `better-auth` that use this pattern were crashing. I fixed it by normalising those inputs to a plain string URL plus options before passing them to the native bridge.

--- a/src/content/i-shipped/async-example-fixes-and-browser-storage-eviction-guidance-in-the-docs.mdx
+++ b/src/content/i-shipped/async-example-fixes-and-browser-storage-eviction-guidance-in-the-docs.mdx
@@ -1,0 +1,7 @@
+---
+summary: async example fixes and browser storage eviction guidance in the docs
+repo: garden-co/jazz2
+mergeDate: 2026-04-30
+prNumber: '708'
+---
+The docs for setting up a Jazz client had Vue and Svelte code examples missing `await` before `createJazzClient`, which returns a Promise — so copying the example would store a pending Promise instead of the actual client. I fixed those snippets and added a new section explaining how browsers can silently delete locally-stored data (called "storage eviction") and how to call `navigator.storage.persist()` to ask the browser to keep your data safe.

--- a/src/content/i-shipped/automatic-browser-reloads-when-schema-changes-are-pushed-in-development.mdx
+++ b/src/content/i-shipped/automatic-browser-reloads-when-schema-changes-are-pushed-in-development.mdx
@@ -1,0 +1,7 @@
+---
+summary: automatic browser reloads when schema changes are pushed in development
+repo: garden-co/jazz2
+mergeDate: 2026-04-29
+prNumber: '715'
+---
+When developing with Jazz in watch mode, editing `schema.ts` now automatically reloads the browser to pick up your changes. Previously you had to manually refresh the page after pushing a schema update to see it take effect. I added a callback that fires after a successful schema push and tells the Vite or SvelteKit dev server to send a full-reload signal to the browser.

--- a/src/content/i-shipped/improved-spinner-ux-and-dotenv-support-for-the-jazz-tools-cli.mdx
+++ b/src/content/i-shipped/improved-spinner-ux-and-dotenv-support-for-the-jazz-tools-cli.mdx
@@ -1,0 +1,7 @@
+---
+summary: improved spinner UX and dotenv support for the jazz-tools CLI
+repo: garden-co/jazz2
+mergeDate: 2026-04-29
+prNumber: '706'
+---
+The `create-jazz` setup tool got two improvements. The spinner now advances to "Provisioning Jazz Cloud app" before making the network request, so it no longer looks frozen on the previous step. I also added support for loading `.env` files so CLI commands like `deploy` can pick up secrets like `JAZZ_ADMIN_SECRET` from a `.env` file instead of requiring them to be set as shell environment variables.


### PR DESCRIPTION
Adds 6 new i-shipped entries for merged PRs from garden-co/jazz2 (2026-04-29 to 2026-04-30):

- **#706**: Improved spinner UX and dotenv support for the jazz-tools CLI
- **#707**: Fix for rows vanishing after schema migrations
- **#708**: Async example fixes and browser storage eviction guidance in the docs
- **#714**: Fix for the Expo fetch polyfill rejecting URL and Request objects
- **#715**: Automatic browser reloads when schema changes are pushed in development
- **#716**: Fix for sign-up failing on React Native after a local-first session

---
_Generated by [Claude Code](https://claude.ai/code/session_01STknDR6rQmNrUiEhqTVaFr)_