### PR TITLE
Add i-shipped entry for garden-co/jazz PR #739

### DIFF
--- a/src/content/i-shipped/a-testing-infrastructure-cleanup-for-the-chat-react-example-app.mdx
+++ b/src/content/i-shipped/a-testing-infrastructure-cleanup-for-the-chat-react-example-app.mdx
@@ -1,0 +1,7 @@
+---
+summary: a testing infrastructure cleanup for the chat-react example app
+repo: garden-co/jazz
+mergeDate: 2026-05-01
+prNumber: '739'
+---
+The chat-react example app had two separate test setups running in parallel — one using Playwright and one using vitest browser mode. I consolidated them by moving the Playwright end-to-end test into the main vitest browser test suite and deleting the now-redundant Playwright config. I also cleaned up some leftover React `act()` wrapper calls that were printing noisy warnings without actually doing anything useful.


### PR DESCRIPTION
Adds a new i-shipped entry for garden-co/jazz PR #739 (merged 2026-05-01): chat-react testing infrastructure cleanup, migrating Playwright e2e tests to vitest browser mode and dropping unnecessary `act()` calls.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSJkS8u5YDkw5gp6cBZEyV)_