### PR TITLE
Add i-shipped entry for garden-co/jazz PR #735

### DIFF
--- a/src/content/i-shipped/auto-reloading-of-nextjs-apps-when-the-schema-is-pushed.mdx
+++ b/src/content/i-shipped/auto-reloading-of-nextjs-apps-when-the-schema-is-pushed.mdx
@@ -1,0 +1,7 @@
+---
+summary: auto-reloading of Next.js apps when the schema is pushed
+repo: garden-co/jazz
+mergeDate: 2026-05-05
+prNumber: '735'
+---
+During Jazz development, whenever you pushed a new schema, you had to manually refresh the browser to pick up the changes. I added a mechanism where the Jazz Webpack/Turbopack plugin writes a small "schema hash" file to a cache directory on every schema push, and the React provider imports this file during development — so the bundler notices the change and automatically reloads the page for you.


### PR DESCRIPTION
Adds entry for garden-co/jazz PR #735: auto-reloading of Next.js apps when the schema is pushed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6V2Man8t77GDAMfdjFPeH)_