### PR TITLE
add 8 new i-shipped entries for garden-co/jazz PRs 814-863

### DIFF
--- a/src/content/i-shipped/a-cleanup-of-the-example-apps-docs-tests-and-feature-parity.mdx
+++ b/src/content/i-shipped/a-cleanup-of-the-example-apps-docs-tests-and-feature-parity.mdx
@@ -1,0 +1,7 @@
+---
+summary: a cleanup of the example apps' docs, tests, and feature parity
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '846'
+---
+Several Jazz example apps had accumulated inconsistencies: some still used Playwright for testing while others had moved to Vitest browser mode, and their docs and feature sets had drifted out of sync. I migrated the remaining auth examples to Vitest browser mode and fixed the various inconsistencies to bring the examples back to parity.

--- a/src/content/i-shipped/a-fix-for-deep-query-subscriptions-losing-reactivity.mdx
+++ b/src/content/i-shipped/a-fix-for-deep-query-subscriptions-losing-reactivity.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for deep query subscriptions losing reactivity
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '861'
+---
+When you subscribed to Jazz data with deeply nested relationships — like posts that include authors that include teams — changes more than one level deep wouldn't trigger a UI update. The subscription system only registered top-level tables as dependencies and missed the deeper ones. I fixed the graph compilation step to walk all nesting levels and register every nested table, so deep mutations correctly invalidate subscriptions.

--- a/src/content/i-shipped/a-fix-for-the-browser-benchmark-suite-being-hidden-from-ci.mdx
+++ b/src/content/i-shipped/a-fix-for-the-browser-benchmark-suite-being-hidden-from-ci.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for the browser benchmark suite being hidden from CI
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '863'
+---
+Two separate regressions had quietly broken the browser benchmark tests so they weren't running in CI at all. A recent refactor changed how database insert results are structured, breaking the seed step, and a separate issue prevented the test files from being discovered. I fixed both problems so the benchmark suite runs correctly again.

--- a/src/content/i-shipped/a-rebuilt-world-tour-example-with-a-custom-globe-and-vue-tests.mdx
+++ b/src/content/i-shipped/a-rebuilt-world-tour-example-with-a-custom-globe-and-vue-tests.mdx
@@ -1,0 +1,7 @@
+---
+summary: a rebuilt world-tour example with a custom globe and Vue tests
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '814'
+---
+The world-tour example app used a third-party map library to display a globe, which was a heavy external dependency. I replaced it with a hand-rolled canvas-based dot globe made from 50,000 Fibonacci sphere points, dropped the dependency entirely, added the example to the monorepo workspace, and included Jazz+Vue integration tests alongside it.

--- a/src/content/i-shipped/a-typescript-type-fix-for-the-sveltekit-plugin-in-strict-mode.mdx
+++ b/src/content/i-shipped/a-typescript-type-fix-for-the-sveltekit-plugin-in-strict-mode.mdx
@@ -1,0 +1,7 @@
+---
+summary: a TypeScript type fix for the SvelteKit plugin in strict mode
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '857'
+---
+Adding the Jazz SvelteKit plugin to `vite.config.ts` with TypeScript strict mode enabled would fail to compile because the plugin's `ssr.external` option was typed as `string[]`, but Vite's actual type is `true | string[]`. I widened the type to match what Vite expects, so it compiles cleanly under strict mode.

--- a/src/content/i-shipped/an-rss-feed-for-the-jazz-docs-blog.mdx
+++ b/src/content/i-shipped/an-rss-feed-for-the-jazz-docs-blog.mdx
@@ -1,0 +1,7 @@
+---
+summary: an RSS feed for the Jazz docs blog
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '841'
+---
+The Jazz docs blog didn't have an RSS feed, so there was no easy way for people to subscribe and be notified of new posts. I added an RSS 2.0 feed at `/rss.xml` built from all blog posts sorted newest-first, and registered it in the site layout so browsers and feed readers can auto-discover it.

--- a/src/content/i-shipped/markdown-serving-for-ai-agents-from-the-jazz-docs.mdx
+++ b/src/content/i-shipped/markdown-serving-for-ai-agents-from-the-jazz-docs.mdx
@@ -1,0 +1,7 @@
+---
+summary: markdown serving for AI agents from the Jazz docs
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '856'
+---
+AI coding assistants work better with plain text than with HTML. I added a proxy to the Jazz docs site that serves any page as clean markdown when a request includes an `Accept: text/markdown` header or a `.md` suffix in the URL, making it easy for AI agents to read the docs directly.

--- a/src/content/i-shipped/three-new-typescript-only-starter-templates.mdx
+++ b/src/content/i-shipped/three-new-typescript-only-starter-templates.mdx
@@ -1,0 +1,7 @@
+---
+summary: three new TypeScript-only starter templates
+repo: garden-co/jazz
+mergeDate: 2026-05-13
+prNumber: '847'
+---
+Jazz's starter templates were all React-based, making it hard to see how Jazz works without a UI framework in the way. I added three new TypeScript-only starters (`ts-localfirst`, `ts-hybrid`, and `ts-betterauth`) that use plain DOM manipulation inside Jazz subscription callbacks, so the core API is front and centre.


### PR DESCRIPTION
Adds 8 new i-shipped entries for garden-co/jazz PRs merged on 2026-05-13:

- Rebuilt world-tour example with custom canvas globe (#814)
- RSS feed for the Jazz docs blog (#841)
- Example apps cleanup: docs, Vitest browser migrations, parity fixes (#846)
- Three new TypeScript-only starter templates (#847)
- Markdown serving for AI agents from docs routes (#856)
- TypeScript type fix for SvelteKit plugin in strict mode (#857)
- Fix for deep query subscriptions losing reactivity (#861)
- Fix for browser benchmark suite being hidden from CI (#863)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWhvCiCo9UKNmv21MqqfEe)_