### PR TITLE
add i-shipped entries for 11 new merged PRs (May 2026)

### DIFF
--- a/src/content/i-shipped/a-cleanup-of-leftover-circle-references-in-docs-and-e2e-tests-for-brightblur.mdx
+++ b/src/content/i-shipped/a-cleanup-of-leftover-circle-references-in-docs-and-e2e-tests-for-brightblur.mdx
@@ -1,0 +1,7 @@
+---
+summary: a cleanup of leftover circle references in docs and e2e tests for BrightBlur
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '37'
+---
+This was housekeeping after the main circle-removal work. I swept remaining mentions of "circle" out of the documentation prose, migrated the end-to-end tests from the old circles concept to the new people-based model, and deleted an old acceptance test suite that had rotted beyond repair. I also fixed a bug where the login throttle was accumulating across test runs, causing "too many requests" errors during automated testing.

--- a/src/content/i-shipped/a-docs-update-reflecting-people-centric-photo-sharing-in-brightblur.mdx
+++ b/src/content/i-shipped/a-docs-update-reflecting-people-centric-photo-sharing-in-brightblur.mdx
@@ -1,0 +1,7 @@
+---
+summary: a docs update reflecting people-centric photo sharing in BrightBlur
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '36'
+---
+I updated all the documentation for BrightBlur to reflect the removal of the old "circles" feature. The app now shares photos based on who's in them — if you tag someone, they and their connections can see the photo — rather than using manually-created circles. I updated the privacy policy, user stories, and the entire user-facing docs site to explain this simpler model.

--- a/src/content/i-shipped/a-fix-for-a-broken-feed-empty-state-and-stale-circle-copy.mdx
+++ b/src/content/i-shipped/a-fix-for-a-broken-feed-empty-state-and-stale-circle-copy.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a broken feed empty-state and sweep of stale circle copy in BrightBlur
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '33'
+---
+I fixed a broken "no photos yet" message in BrightBlur that was telling new users to "Create a circle to start sharing" — but circles had been removed, so that button was dead and the message was wrong. I replaced it with instructions matching how sharing actually works now. I also swept through the rest of the app to remove other leftover circle references and tidy up the navigation.

--- a/src/content/i-shipped/a-fix-for-a-flaky-offline-banner-test-that-was-matching-the-wrong-element.mdx
+++ b/src/content/i-shipped/a-fix-for-a-flaky-offline-banner-test-that-was-matching-the-wrong-element.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a flaky offline banner test that was matching the wrong element
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '38'
+---
+I fixed a flaky end-to-end test for BrightBlur's offline banner. The test was checking whether the "offline" banner disappeared after reconnecting to the network, but the element locator was too broad — it matched the word "Offline" in a photo caption, not just the actual banner. So even after the real banner hid itself, the test kept finding the caption and failing. I scoped the locator to only look inside the `role="status"` region where the real banner lives.

--- a/src/content/i-shipped/a-new-person-settings-page-for-managing-person-groups-in-brightblur.mdx
+++ b/src/content/i-shipped/a-new-person-settings-page-for-managing-person-groups-in-brightblur.mdx
@@ -1,0 +1,7 @@
+---
+summary: a new person settings page for managing person-groups in BrightBlur
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '31'
+---
+In BrightBlur, every "person" you recognise in photos has an associated group that controls who can see photos featuring them. I added a proper settings page at `/people/[id]/settings` where admins can manage that group — rename it, add or remove members, transfer ownership, or delete it. Previously these actions were scattered across the UI or effectively unreachable.

--- a/src/content/i-shipped/a-refactor-making-brightblurs-groups-page-people-only-and-preventing-circle-creation.mdx
+++ b/src/content/i-shipped/a-refactor-making-brightblurs-groups-page-people-only-and-preventing-circle-creation.mdx
@@ -1,0 +1,7 @@
+---
+summary: a refactor making BrightBlur's groups page people-only and preventing circle creation
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '32'
+---
+With person management now moved to its own settings page, I simplified BrightBlur's groups page to only show people (not circles). I also locked the "create group" API so it can only create person-type groups — circles were already useless at this point, but this closes off the last way to create them.

--- a/src/content/i-shipped/a-refactor-removing-the-explicit-circles-feature-from-brightblur.mdx
+++ b/src/content/i-shipped/a-refactor-removing-the-explicit-circles-feature-from-brightblur.mdx
@@ -1,0 +1,7 @@
+---
+summary: a refactor removing the explicit circles feature from BrightBlur
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '30'
+---
+BrightBlur used to let you create "circles" — named groups you could manually add people to and use to filter who sees a photo. I removed this feature in favour of a simpler model: photos automatically reach everyone connected to the faces tagged in them. This involved removing the default-circles settings, the audience picker's circle bucket, the feed's circle filter, and the join-request flow, along with a database migration that deleted all existing circle data.

--- a/src/content/i-shipped/a-rename-of-an-internal-key-unwrapping-function-to-reflect-generic-groups.mdx
+++ b/src/content/i-shipped/a-rename-of-an-internal-key-unwrapping-function-to-reflect-generic-groups.mdx
@@ -1,0 +1,7 @@
+---
+summary: a rename of an internal key-unwrapping function to reflect generic groups
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '35'
+---
+I renamed an internal function called `unwrapCircleEpochKey` to `unwrapGroupEpochKey` — the function actually works for any kind of group, not just circles, so the old name was misleading. This was a pure code cleanup with no effect on how the app behaves.

--- a/src/content/i-shipped/a-security-fix-for-unauthenticated-oom-via-websocket-handshake-decompression.mdx
+++ b/src/content/i-shipped/a-security-fix-for-unauthenticated-oom-via-websocket-handshake-decompression.mdx
@@ -1,0 +1,7 @@
+---
+summary: a security fix for unauthenticated OOM via WebSocket handshake decompression
+repo: garden-co/jazz
+mergeDate: 2026-05-28
+prNumber: '955'
+---
+I found that the WebSocket handshake frame (the first message when a new connection opens) was being decompressed before we'd checked who was connecting. A malicious actor could send a tiny compressed frame that claimed to expand to gigabytes, crashing the server by running out of memory. I added a check that rejects any handshake frame claiming to be larger than 1 MB — since a real handshake is only a few kilobytes of data, anything bigger is suspicious.

--- a/src/content/i-shipped/a-terminology-update-and-cleanup-of-dead-circle-handling-code-in-brightblur.mdx
+++ b/src/content/i-shipped/a-terminology-update-and-cleanup-of-dead-circle-handling-code-in-brightblur.mdx
@@ -1,0 +1,7 @@
+---
+summary: a terminology update and cleanup of dead circle-handling code in BrightBlur
+repo: joeinnes/brightblur
+mergeDate: 2026-05-26
+prNumber: '34'
+---
+I updated the user-facing language in BrightBlur: "My circle" became "You", "Others' circles" became "Other people", and a notification that said someone joined your circle now says they can see a person instead. I also removed dead code that was still checking for circle memberships during account deletion — those memberships no longer exist, so the code never ran. The cleanup now correctly removes encryption keys across all groups when an account is deleted.

--- a/src/content/i-shipped/per-user-supplementary-face-recognition-and-a-feed-filter-cache-for-brightblur.mdx
+++ b/src/content/i-shipped/per-user-supplementary-face-recognition-and-a-feed-filter-cache-for-brightblur.mdx
@@ -1,0 +1,7 @@
+---
+summary: per-user supplementary face recognition and a feed filter cache for BrightBlur
+repo: joeinnes/brightblur
+mergeDate: 2026-05-25
+prNumber: '29'
+---
+I shipped two improvements to BrightBlur. First, I added a short-lived cache for the photo feed's filter results so that switching between filters no longer triggers a flood of requests — this was causing "503 server too busy" errors on rapid toggling. Second, I improved face recognition so that when you tag someone, your own unconfirmed tags are immediately used to help recognise that person in your next upload, without waiting for the identity owner to approve them.


### PR DESCRIPTION
Adds 11 new i-shipped entries covering merged PRs from 2026-05-25 to 2026-05-28.

**joeinnes/brightblur** (10 PRs, #29–38):
- Per-user supplementary face recognition + feed filter cache
- Remove explicit circles refactor (phased across multiple PRs)
- New person settings page for managing person-groups
- People-only groups page + lock circle creation
- Sweep of stale circle copy + broken feed empty-state fix
- People-centric terminology + dead code cleanup
- Internal function rename (unwrapCircleEpochKey → unwrapGroupEpochKey)
- Docs update reflecting people-centric sharing
- Circle cleanup in docs and e2e tests
- Flaky offline banner test fix

**garden-co/jazz** (1 PR, #955):
- Security fix for unauthenticated OOM via WebSocket handshake decompression

---
_Generated by [Claude Code](https://claude.ai/code/session_01NP7UUBLLpCbHSdD5czm2Gq)_