### PR TITLE
Fix i-shipped links after garden-co/jazz repo renames

### DIFF
--- a/src/content/i-shipped/a-bugfix-for-an-issue-where-ensure-loaded-was-throwing-despite-on-error-catch-being-set.mdx
+++ b/src/content/i-shipped/a-bugfix-for-an-issue-where-ensure-loaded-was-throwing-despite-on-error-catch-being-set.mdx
@@ -2,7 +2,7 @@
 summary: >-
   a bugfix for an issue where `ensureLoaded` was throwing despite `$onError:
   'catch'` being set
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-25
 prNumber: '3204'
 ---

--- a/src/content/i-shipped/a-built-in-mcp-docs-server-for-jazz-tools.mdx
+++ b/src/content/i-shipped/a-built-in-mcp-docs-server-for-jazz-tools.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a built-in MCP docs server for jazz-tools
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-05
 prNumber: '211'
 ---

--- a/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-in-jazz2.mdx
+++ b/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-in-jazz2.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a change to install wasm-pack via cargo in jazz2
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-31
 prNumber: '427'
 ---

--- a/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-instead-of-npm.mdx
+++ b/src/content/i-shipped/a-change-to-install-wasm-pack-via-cargo-instead-of-npm.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a change to install wasm-pack via cargo instead of npm
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-31
 prNumber: '3515'
 ---

--- a/src/content/i-shipped/a-cleanup-of-the-example-apps-docs-tests-and-feature-parity.mdx
+++ b/src/content/i-shipped/a-cleanup-of-the-example-apps-docs-tests-and-feature-parity.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a cleanup of the example apps' docs, tests, and feature parity
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '846'
 ---

--- a/src/content/i-shipped/a-cleanup-of-the-example-apps-docs-tests-and-feature-parity.mdx
+++ b/src/content/i-shipped/a-cleanup-of-the-example-apps-docs-tests-and-feature-parity.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a cleanup of the example apps' docs, tests, and feature parity
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '846'
 ---

--- a/src/content/i-shipped/a-compatibility-fix-for-better-auth-1-5-3-in-jazz-tools.mdx
+++ b/src/content/i-shipped/a-compatibility-fix-for-better-auth-1-5-3-in-jazz-tools.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a compatibility fix for better-auth 1.5.3 in jazz-tools
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-07
 prNumber: '3488'
 ---

--- a/src/content/i-shipped/a-created-by-getter-allowing-users-to-quickly-work-out-who-created-a-particular-co-value.mdx
+++ b/src/content/i-shipped/a-created-by-getter-allowing-users-to-quickly-work-out-who-created-a-particular-co-value.mdx
@@ -2,7 +2,7 @@
 summary: >-
   a `createdBy` getter allowing users to quickly work out who created a
   particular CoValue
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-30
 prNumber: '3246'
 ---

--- a/src/content/i-shipped/a-custom-declarative-diagram-engine-to-replace-mermaid-in-the-docs.mdx
+++ b/src/content/i-shipped/a-custom-declarative-diagram-engine-to-replace-mermaid-in-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a custom declarative diagram engine to replace Mermaid in the Jazz docs
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-22
 prNumber: '912'
 ---

--- a/src/content/i-shipped/a-dashboard-link-to-the-jazz-docs-site-navigation.mdx
+++ b/src/content/i-shipped/a-dashboard-link-to-the-jazz-docs-site-navigation.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a Dashboard link to the Jazz docs site navigation
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-15
 prNumber: '895'
 ---

--- a/src/content/i-shipped/a-dedicated-docs-section-for-read-durability-tiers.mdx
+++ b/src/content/i-shipped/a-dedicated-docs-section-for-read-durability-tiers.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a dedicated docs section for read durability tiers
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-14
 prNumber: '504'
 ---

--- a/src/content/i-shipped/a-docs-update-regarding-credential-persistence-on-i-os.mdx
+++ b/src/content/i-shipped/a-docs-update-regarding-credential-persistence-on-i-os.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a docs update regarding credential persistence on iOS
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-24
 prNumber: '3200'
 ---

--- a/src/content/i-shipped/a-docs-url-update-in-starter-agentsmd-files.mdx
+++ b/src/content/i-shipped/a-docs-url-update-in-starter-agentsmd-files.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a docs URL update in starter AGENTS.md files
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-22
 prNumber: '636'
 ---

--- a/src/content/i-shipped/a-documented-new-pattern-for-credential-storage-on-i-os.mdx
+++ b/src/content/i-shipped/a-documented-new-pattern-for-credential-storage-on-i-os.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a documented new pattern for credential storage on iOS
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-17
 prNumber: '3277'
 ---

--- a/src/content/i-shipped/a-fix-for-a-better-auth-race-condition.mdx
+++ b/src/content/i-shipped/a-fix-for-a-better-auth-race-condition.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a Better Auth race condition
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-04-10
 prNumber: '3519'
 ---

--- a/src/content/i-shipped/a-fix-for-a-bug-in-our-types-for-loading-options-on-co-feeds.mdx
+++ b/src/content/i-shipped/a-fix-for-a-bug-in-our-types-for-loading-options-on-co-feeds.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a bug in our types for loading options on CoFeeds
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-29
 prNumber: '3114'
 ---

--- a/src/content/i-shipped/a-fix-for-a-callback-race-condition-in-subscriptions.mdx
+++ b/src/content/i-shipped/a-fix-for-a-callback-race-condition-in-subscriptions.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a callback race condition in subscriptions
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-05
 prNumber: '210'
 ---

--- a/src/content/i-shipped/a-fix-for-a-hang-in-create-jazz-context-when-schema-migrations-fail.mdx
+++ b/src/content/i-shipped/a-fix-for-a-hang-in-create-jazz-context-when-schema-migrations-fail.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a hang in createJazzContext when schema migrations fail
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-04-10
 prNumber: '3520'
 ---

--- a/src/content/i-shipped/a-fix-for-a-jazzprovider-cleanup-cycle-caused-by-config-object-references.mdx
+++ b/src/content/i-shipped/a-fix-for-a-jazzprovider-cleanup-cycle-caused-by-config-object-references.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a JazzProvider cleanup cycle caused by config object references
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-23
 prNumber: '659'
 ---

--- a/src/content/i-shipped/a-fix-for-a-quirk-of-the-web-locks-api-in-safari.mdx
+++ b/src/content/i-shipped/a-fix-for-a-quirk-of-the-web-locks-api-in-safari.mdx
@@ -2,6 +2,6 @@
 summary: a fix for a quirk of the Web Locks API in Safari
 repo: garden-co/classic-jazz
 mergeDate: 2025-12-14
-prNumber: '#3274'
+prNumber: '3274'
 ---
 Safari's Web Locks API doesn't release immediately on navigation, which was causing the browser to effectively hang when viewing our docs landing page. This PR moved the co-ordination of the routes to a parent component.

--- a/src/content/i-shipped/a-fix-for-a-quirk-of-the-web-locks-api-in-safari.mdx
+++ b/src/content/i-shipped/a-fix-for-a-quirk-of-the-web-locks-api-in-safari.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a quirk of the Web Locks API in Safari
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-14
 prNumber: '#3274'
 ---

--- a/src/content/i-shipped/a-fix-for-a-race-condition-in-our-auth-storage-code.mdx
+++ b/src/content/i-shipped/a-fix-for-a-race-condition-in-our-auth-storage-code.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a race condition in our auth storage code
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-19
 prNumber: '3505'
 ---

--- a/src/content/i-shipped/a-fix-for-a-react-native-ui-freeze-caused-by-synchronous-database-queries.mdx
+++ b/src/content/i-shipped/a-fix-for-a-react-native-ui-freeze-caused-by-synchronous-database-queries.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a React Native UI freeze caused by synchronous database queries
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-06
 prNumber: '800'
 ---

--- a/src/content/i-shipped/a-fix-for-a-stale-repository-reference-in-the-create-jazz-scaffolding-tool.mdx
+++ b/src/content/i-shipped/a-fix-for-a-stale-repository-reference-in-the-create-jazz-scaffolding-tool.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a stale repository reference in the create-jazz scaffolding tool
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-04
 prNumber: '775'
 ---

--- a/src/content/i-shipped/a-fix-for-broken-polyfills-in-the-expo-integration-that-were-crashing-third-party-libraries.mdx
+++ b/src/content/i-shipped/a-fix-for-broken-polyfills-in-the-expo-integration-that-were-crashing-third-party-libraries.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for broken polyfills in the Expo integration that were crashing third-party libraries
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-07
 prNumber: '802'
 ---

--- a/src/content/i-shipped/a-fix-for-broken-polyfills-in-the-expo-integration-that-were-crashing-third-party-libraries.mdx
+++ b/src/content/i-shipped/a-fix-for-broken-polyfills-in-the-expo-integration-that-were-crashing-third-party-libraries.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for broken polyfills in the Expo integration that were crashing third-party libraries
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-07
 prNumber: '802'
 ---

--- a/src/content/i-shipped/a-fix-for-corrupted-columns-on-subscription-updates.mdx
+++ b/src/content/i-shipped/a-fix-for-corrupted-columns-on-subscription-updates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for corrupted columns on subscription updates
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-02
 prNumber: '185'
 ---

--- a/src/content/i-shipped/a-fix-for-deep-query-subscriptions-losing-reactivity.mdx
+++ b/src/content/i-shipped/a-fix-for-deep-query-subscriptions-losing-reactivity.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for deep query subscriptions losing reactivity
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '861'
 ---

--- a/src/content/i-shipped/a-fix-for-drop-column-generation-in-multi-table-migrations.mdx
+++ b/src/content/i-shipped/a-fix-for-drop-column-generation-in-multi-table-migrations.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for DROP COLUMN generation in multi-table migrations
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-02
 prNumber: '187'
 ---

--- a/src/content/i-shipped/a-fix-for-empty-query-results-from-anonymous-clients.mdx
+++ b/src/content/i-shipped/a-fix-for-empty-query-results-from-anonymous-clients.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for empty query results from anonymous clients
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-05
 prNumber: '198'
 ---

--- a/src/content/i-shipped/a-fix-for-garbled-query-results-when-using-include.mdx
+++ b/src/content/i-shipped/a-fix-for-garbled-query-results-when-using-include.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for garbled query results when using include
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-02-23
 prNumber: '107'
 ---

--- a/src/content/i-shipped/a-fix-for-incorrect-pluralization-in-the-code-generator.mdx
+++ b/src/content/i-shipped/a-fix-for-incorrect-pluralization-in-the-code-generator.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for incorrect pluralization in the code generator
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-02-23
 prNumber: '105'
 ---

--- a/src/content/i-shipped/a-fix-for-invalid-signature-errors-when-concurrent-writes-happen.mdx
+++ b/src/content/i-shipped/a-fix-for-invalid-signature-errors-when-concurrent-writes-happen.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for InvalidSignature errors when concurrent writes happen
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-31
 prNumber: '3514'
 ---

--- a/src/content/i-shipped/a-fix-for-mcp-server-crashes-when-nodesqlite-is-unavailable.mdx
+++ b/src/content/i-shipped/a-fix-for-mcp-server-crashes-when-nodesqlite-is-unavailable.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   a fix for MCP server crashes when node:sqlite is unavailable
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-21
 prNumber: '910'
 ---

--- a/src/content/i-shipped/a-fix-for-mcp-server-crashes-when-nodesqlite-is-unavailable.mdx
+++ b/src/content/i-shipped/a-fix-for-mcp-server-crashes-when-nodesqlite-is-unavailable.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   a fix for MCP server crashes when node:sqlite is unavailable
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-21
 prNumber: '910'
 ---

--- a/src/content/i-shipped/a-fix-for-missing-policy-enforcement-in-queries.mdx
+++ b/src/content/i-shipped/a-fix-for-missing-policy-enforcement-in-queries.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for missing policy enforcement in queries
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-02-27
 prNumber: '147'
 ---

--- a/src/content/i-shipped/a-fix-for-policy-evaluation-with-ephemeral-claims.mdx
+++ b/src/content/i-shipped/a-fix-for-policy-evaluation-with-ephemeral-claims.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for policy evaluation with ephemeral claims
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-27
 prNumber: '353'
 ---

--- a/src/content/i-shipped/a-fix-for-rows-vanishing-after-schema-migrations.mdx
+++ b/src/content/i-shipped/a-fix-for-rows-vanishing-after-schema-migrations.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for rows vanishing after schema migrations
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-29
 prNumber: '707'
 ---

--- a/src/content/i-shipped/a-fix-for-sign-up-failing-on-react-native-after-a-local-first-session.mdx
+++ b/src/content/i-shipped/a-fix-for-sign-up-failing-on-react-native-after-a-local-first-session.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for sign-up failing on React Native after a local-first session
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-30
 prNumber: '716'
 ---

--- a/src/content/i-shipped/a-fix-for-startup-and-auth-issues-in-several-example-apps.mdx
+++ b/src/content/i-shipped/a-fix-for-startup-and-auth-issues-in-several-example-apps.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for startup and auth issues in several example apps
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-27
 prNumber: '637'
 ---

--- a/src/content/i-shipped/a-fix-for-svelte-state-referenced-locally-warnings.mdx
+++ b/src/content/i-shipped/a-fix-for-svelte-state-referenced-locally-warnings.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for Svelte state_referenced_locally warnings
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-03
 prNumber: '445'
 ---

--- a/src/content/i-shipped/a-fix-for-the-browser-benchmark-suite-being-hidden-from-ci.mdx
+++ b/src/content/i-shipped/a-fix-for-the-browser-benchmark-suite-being-hidden-from-ci.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for the browser benchmark suite being hidden from CI
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '863'
 ---

--- a/src/content/i-shipped/a-fix-for-the-expo-fetch-polyfill-rejecting-url-and-request-objects.mdx
+++ b/src/content/i-shipped/a-fix-for-the-expo-fetch-polyfill-rejecting-url-and-request-objects.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for the Expo fetch polyfill rejecting URL and Request objects
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-29
 prNumber: '714'
 ---

--- a/src/content/i-shipped/a-fix-for-the-jazz-tools-cli-silently-doing-nothing-when-run-through-pnpm.mdx
+++ b/src/content/i-shipped/a-fix-for-the-jazz-tools-cli-silently-doing-nothing-when-run-through-pnpm.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for the jazz-tools CLI silently doing nothing when run through pnpm
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-18
 prNumber: '891'
 ---

--- a/src/content/i-shipped/a-fix-for-the-responsive-image-component-to-avoid-an-ugly-flash-of-alt-text.mdx
+++ b/src/content/i-shipped/a-fix-for-the-responsive-image-component-to-avoid-an-ugly-flash-of-alt-text.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for the responsive image component to avoid an ugly flash of alt text
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 prNumber: '2942'
 mergeDate: 2025-09-22
 ---

--- a/src/content/i-shipped/a-fix-for-the-sveltekit-dev-plugin-failing-to-apply-config-on-cold-start.mdx
+++ b/src/content/i-shipped/a-fix-for-the-sveltekit-dev-plugin-failing-to-apply-config-on-cold-start.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for the SvelteKit dev plugin failing to apply config on cold start
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-27
 prNumber: '671'
 ---

--- a/src/content/i-shipped/a-fix-for-ugly-scrollbar-display-when-using-mac-os-trackpads.mdx
+++ b/src/content/i-shipped/a-fix-for-ugly-scrollbar-display-when-using-mac-os-trackpads.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for ugly scrollbar display when using macOS trackpads
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-08
 prNumber: '3020'
 ---

--- a/src/content/i-shipped/a-fix-for-worker-url-resolution-in-bundlers.mdx
+++ b/src/content/i-shipped/a-fix-for-worker-url-resolution-in-bundlers.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for worker URL resolution in bundlers
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-17
 prNumber: '540'
 ---

--- a/src/content/i-shipped/a-fix-to-add-jazz-wasm-as-a-direct-dependency-to-vite-based-starters.mdx
+++ b/src/content/i-shipped/a-fix-to-add-jazz-wasm-as-a-direct-dependency-to-vite-based-starters.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix to add jazz-wasm as a direct dependency to Vite-based starters
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-23
 prNumber: '654'
 ---

--- a/src/content/i-shipped/a-fix-to-always-run-the-schema-build-on-every-build.mdx
+++ b/src/content/i-shipped/a-fix-to-always-run-the-schema-build-on-every-build.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix to always run the schema build on every build
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-12
 prNumber: '312'
 ---

--- a/src/content/i-shipped/a-fix-to-eliminate-critical-security-vulnerabilities.mdx
+++ b/src/content/i-shipped/a-fix-to-eliminate-critical-security-vulnerabilities.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix to eliminate critical security vulnerabilities
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-22
 prNumber: '3079'
 ---

--- a/src/content/i-shipped/a-fix-to-our-homepage-after-an-update-caused-overflow-on-basically-every-element-resulting-in-scrollbars-appearing-everywhere.mdx
+++ b/src/content/i-shipped/a-fix-to-our-homepage-after-an-update-caused-overflow-on-basically-every-element-resulting-in-scrollbars-appearing-everywhere.mdx
@@ -2,7 +2,7 @@
 summary: >-
   a fix to our homepage after an update caused overflow on basically every
   element, resulting in scrollbars appearing everywhere.
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-09
 prNumber: '3029'
 ---

--- a/src/content/i-shipped/a-fix-to-our-passkey-implementation-which-increases-the-challenge-length-to-20-bytes.mdx
+++ b/src/content/i-shipped/a-fix-to-our-passkey-implementation-which-increases-the-challenge-length-to-20-bytes.mdx
@@ -2,7 +2,7 @@
 summary: >-
   a fix to our passkey implementation which increases the challenge length to 20
   bytes
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-29
 prNumber: '2977'
 ---

--- a/src/content/i-shipped/a-fix-to-the-discriminated-union-docs-to-make-it-clearer-what-operations-we-do-and-don-t-support.mdx
+++ b/src/content/i-shipped/a-fix-to-the-discriminated-union-docs-to-make-it-clearer-what-operations-we-do-and-don-t-support.mdx
@@ -2,7 +2,7 @@
 summary: >-
   a fix to the discriminated union docs to make it clearer what operations we do
   and don't support
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-29
 prNumber: '2981'
 ---

--- a/src/content/i-shipped/a-fix-to-wait-for-membership-confirmation-before-enabling-the-chat-composer.mdx
+++ b/src/content/i-shipped/a-fix-to-wait-for-membership-confirmation-before-enabling-the-chat-composer.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix to wait for membership confirmation before enabling the chat composer
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-27
 prNumber: '662'
 ---

--- a/src/content/i-shipped/a-friendlier-api-for-permission-relation-names.mdx
+++ b/src/content/i-shipped/a-friendlier-api-for-permission-relation-names.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a friendlier API for permission relation names
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-08
 prNumber: '476'
 ---

--- a/src/content/i-shipped/a-full-chat-example-with-permissions-and-invite-flow.mdx
+++ b/src/content/i-shipped/a-full-chat-example-with-permissions-and-invite-flow.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a full chat example with permissions and invite flow
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-20
 prNumber: '313'
 ---

--- a/src/content/i-shipped/a-get-or-create-method-which-complements-the-upsert-unique-functionality.mdx
+++ b/src/content/i-shipped/a-get-or-create-method-which-complements-the-upsert-unique-functionality.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a `getOrCreate` method which complements the `upsertUnique` functionality
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 prNumber: '2997'
 ---
 Currently, users can `upsertUnique`, allowing them to specify a piece of unique data to be used to generate the header for their CoValue. This existing function will either create or overwrite any CoValue with that specific uniqueness.

--- a/src/content/i-shipped/a-guide-on-how-to-model-data-in-a-jazz-application.mdx
+++ b/src/content/i-shipped/a-guide-on-how-to-model-data-in-a-jazz-application.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a guide on how to model data in a Jazz application
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-23
 prNumber: '3391'
 ---

--- a/src/content/i-shipped/a-huge-docs-update-removing-twoslash-in-favour-of-extracted-code-snippets.mdx
+++ b/src/content/i-shipped/a-huge-docs-update-removing-twoslash-in-favour-of-extracted-code-snippets.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a huge docs update, removing twoslash in favour of extracted code snippets
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-07
 prNumber: '3090'
 ---

--- a/src/content/i-shipped/a-link-validation-script-for-our-docs-pages.mdx
+++ b/src/content/i-shipped/a-link-validation-script-for-our-docs-pages.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a link validation script for our docs pages
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-20
 prNumber: '3388'
 ---

--- a/src/content/i-shipped/a-minor-fix-for-a-regression-introduced-in-our-navigation.mdx
+++ b/src/content/i-shipped/a-minor-fix-for-a-regression-introduced-in-our-navigation.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a minor fix for a regression introduced in our navigation
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-10
 prNumber: '3262'
 ---

--- a/src/content/i-shipped/a-module-type-declaration-fix-for-the-jazz-wasm-package.mdx
+++ b/src/content/i-shipped/a-module-type-declaration-fix-for-the-jazz-wasm-package.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   a module type declaration fix for the jazz-wasm package
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-17
 prNumber: '543'
 ---

--- a/src/content/i-shipped/a-moon-lander-multiplayer-game-example.mdx
+++ b/src/content/i-shipped/a-moon-lander-multiplayer-game-example.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a moon lander multiplayer game example
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-08
 prNumber: '235'
 ---

--- a/src/content/i-shipped/a-new-not-found-page.mdx
+++ b/src/content/i-shipped/a-new-not-found-page.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a new Not Found page
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-17
 prNumber: '3063'
 ---

--- a/src/content/i-shipped/a-new-section-for-our-docs-offering-performance-tips-for-advanced-users.mdx
+++ b/src/content/i-shipped/a-new-section-for-our-docs-offering-performance-tips-for-advanced-users.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a new section for our docs offering performance tips for advanced users
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-14
 prNumber: '3038'
 ---

--- a/src/content/i-shipped/a-new-section-for-vanilla-users.mdx
+++ b/src/content/i-shipped/a-new-section-for-vanilla-users.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a new section for vanilla users
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-30
 prNumber: '3111'
 ---

--- a/src/content/i-shipped/a-new-testing-section-for-our-docs.mdx
+++ b/src/content/i-shipped/a-new-testing-section-for-our-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a new 'Testing' section for our docs
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-24
 prNumber: '3092'
 ---

--- a/src/content/i-shipped/a-new-way-to-create-invites-to-groups.mdx
+++ b/src/content/i-shipped/a-new-way-to-create-invites-to-groups.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a new way to create invites to groups
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-13
 prNumber: '3043'
 ---

--- a/src/content/i-shipped/a-note-in-our-docs-warning-of-the-risk-of-xss-attacks.mdx
+++ b/src/content/i-shipped/a-note-in-our-docs-warning-of-the-risk-of-xss-attacks.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a note in our docs warning of the risk of XSS attacks
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-04
 prNumber: '3110'
 ---

--- a/src/content/i-shipped/a-performance-tip-for-using-selectors.mdx
+++ b/src/content/i-shipped/a-performance-tip-for-using-selectors.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a performance tip for using selectors
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-02
 prNumber: '3232'
 ---

--- a/src/content/i-shipped/a-pr-to-fix-an-infinite-navigation-loop-on-our-docs.mdx
+++ b/src/content/i-shipped/a-pr-to-fix-an-infinite-navigation-loop-on-our-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a PR to fix an infinite navigation loop on our docs
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-10
 prNumber: '3171'
 ---

--- a/src/content/i-shipped/a-quick-fix-to-address-a-security-issue-in-next.mdx
+++ b/src/content/i-shipped/a-quick-fix-to-address-a-security-issue-in-next.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a quick fix to address a security issue in Next
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-12
 prNumber: '3265'
 ---

--- a/src/content/i-shipped/a-quick-fix-to-upgrade-our-svelte-versions.mdx
+++ b/src/content/i-shipped/a-quick-fix-to-upgrade-our-svelte-versions.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a quick fix to upgrade our Svelte versions
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-19
 prNumber: '3373'
 ---

--- a/src/content/i-shipped/a-react-quick-start-guide.mdx
+++ b/src/content/i-shipped/a-react-quick-start-guide.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a React quick start guide
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-02-19
 prNumber: '86'
 ---

--- a/src/content/i-shipped/a-rebuilt-world-tour-example-with-a-custom-globe-and-vue-tests.mdx
+++ b/src/content/i-shipped/a-rebuilt-world-tour-example-with-a-custom-globe-and-vue-tests.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a rebuilt world-tour example with a custom globe and Vue tests
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '814'
 ---

--- a/src/content/i-shipped/a-refactoring-of-our-use-framework-hook.mdx
+++ b/src/content/i-shipped/a-refactoring-of-our-use-framework-hook.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a refactoring of our useFramework hook
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-24
 prNumber: '3172'
 ---

--- a/src/content/i-shipped/a-reorganisation-of-recipe-docs-and-a-new-group-permissions-recipe.mdx
+++ b/src/content/i-shipped/a-reorganisation-of-recipe-docs-and-a-new-group-permissions-recipe.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a reorganisation of recipe docs and a new group permissions recipe
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-27
 prNumber: '668'
 ---

--- a/src/content/i-shipped/a-revision-for-our-docs-adding-multiple-frameworks-to-the-forms-design-pattern-page.mdx
+++ b/src/content/i-shipped/a-revision-for-our-docs-adding-multiple-frameworks-to-the-forms-design-pattern-page.mdx
@@ -2,7 +2,7 @@
 summary: >-
   a revision for our docs adding multiple frameworks to the Forms design pattern
   page
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 prNumber: '3270'
 ---
 Our docs previously showed some useful patterns for working with forms in React. Now, they show in all the frameworks we support.

--- a/src/content/i-shipped/a-schema-hash-cli-command.mdx
+++ b/src/content/i-shipped/a-schema-hash-cli-command.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a schema hash CLI command
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-22
 prNumber: '616'
 ---

--- a/src/content/i-shipped/a-security-fix-for-unauthenticated-oom-via-websocket-handshake-decompression.mdx
+++ b/src/content/i-shipped/a-security-fix-for-unauthenticated-oom-via-websocket-handshake-decompression.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a security fix for unauthenticated OOM via WebSocket handshake decompression
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-28
 prNumber: '955'
 ---

--- a/src/content/i-shipped/a-small-docs-update-to-clarify-how-to-use-recursive-references.mdx
+++ b/src/content/i-shipped/a-small-docs-update-to-clarify-how-to-use-recursive-references.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a small docs update to clarify how to use recursive references.
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-16
 prNumber: '2922'
 ---

--- a/src/content/i-shipped/a-sveltekit-vite-plugin-for-jazz.mdx
+++ b/src/content/i-shipped/a-sveltekit-vite-plugin-for-jazz.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a SvelteKit Vite plugin for Jazz
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-15
 prNumber: '522'
 ---

--- a/src/content/i-shipped/a-testing-infrastructure-cleanup-for-the-chat-react-example-app.mdx
+++ b/src/content/i-shipped/a-testing-infrastructure-cleanup-for-the-chat-react-example-app.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a testing infrastructure cleanup for the chat-react example app
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-01
 prNumber: '739'
 ---

--- a/src/content/i-shipped/a-type-import-fix-in-the-svelte-quickstart-example.mdx
+++ b/src/content/i-shipped/a-type-import-fix-in-the-svelte-quickstart-example.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a type import fix in the Svelte quickstart example
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-11
 prNumber: '3476'
 ---

--- a/src/content/i-shipped/a-type-level-fix-for-hopto-destination-row-type-inference.mdx
+++ b/src/content/i-shipped/a-type-level-fix-for-hopto-destination-row-type-inference.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a type-level fix for hopTo destination row type inference
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-14
 prNumber: '877'
 ---

--- a/src/content/i-shipped/a-typescript-type-fix-for-the-sveltekit-plugin-in-strict-mode.mdx
+++ b/src/content/i-shipped/a-typescript-type-fix-for-the-sveltekit-plugin-in-strict-mode.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a TypeScript type fix for the SvelteKit plugin in strict mode
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '857'
 ---

--- a/src/content/i-shipped/a-unified-signature-for-create-invite-link-across-core-and-browser.mdx
+++ b/src/content/i-shipped/a-unified-signature-for-create-invite-link-across-core-and-browser.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a unified signature for createInviteLink across core and browser
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-04-01
 prNumber: '3507'
 ---

--- a/src/content/i-shipped/a-vue-3-example-app-showcasing-jazz.mdx
+++ b/src/content/i-shipped/a-vue-3-example-app-showcasing-jazz.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a Vue 3 example app showcasing Jazz
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-01
 prNumber: '408'
 ---

--- a/src/content/i-shipped/a-vue-3-todo-example-for-jazz.mdx
+++ b/src/content/i-shipped/a-vue-3-todo-example-for-jazz.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a Vue 3 todo example for Jazz
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-18
 prNumber: '878'
 ---

--- a/src/content/i-shipped/add-a-512px-progressive-image-variant.mdx
+++ b/src/content/i-shipped/add-a-512px-progressive-image-variant.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add a 512px progressive image variant
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-16
 prNumber: '3376'
 ---

--- a/src/content/i-shipped/add-a-delete-local-storage-option-to-the-inspector.mdx
+++ b/src/content/i-shipped/add-a-delete-local-storage-option-to-the-inspector.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   add a 'delete local storage' option to the inspector
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-09
 prNumber: '2884'
 ---

--- a/src/content/i-shipped/add-a-docs-index-to-agentsmd.mdx
+++ b/src/content/i-shipped/add-a-docs-index-to-agentsmd.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add a docs index to AGENTS.md
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-11
 prNumber: '3445'
 ---

--- a/src/content/i-shipped/add-a-hash.mdx
+++ b/src/content/i-shipped/add-a-hash.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add a hash
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-15
 prNumber: '3283'
 ---

--- a/src/content/i-shipped/add-contextual-error-hints-when-covalue-cant-load-due-to-sync-config.mdx
+++ b/src/content/i-shipped/add-contextual-error-hints-when-covalue-cant-load-due-to-sync-config.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   contextual error hints when a CoValue can't load due to sync config
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-17
 prNumber: '3465'
 ---

--- a/src/content/i-shipped/add-custom-placeholders-for-image-components.mdx
+++ b/src/content/i-shipped/add-custom-placeholders-for-image-components.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add custom placeholders for Image components
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-22
 prNumber: '2937'
 ---

--- a/src/content/i-shipped/add-improved-docs-for-suspenseerror-boundaries.mdx
+++ b/src/content/i-shipped/add-improved-docs-for-suspenseerror-boundaries.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add improved docs for Suspense/Error Boundaries
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-13
 prNumber: '3359'
 ---

--- a/src/content/i-shipped/add-jazz-workflow-world-documentation.mdx
+++ b/src/content/i-shipped/add-jazz-workflow-world-documentation.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add Jazz Workflow World documentation
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-11
 prNumber: '3135'
 ---

--- a/src/content/i-shipped/add-some-skills-and-reference-material.mdx
+++ b/src/content/i-shipped/add-some-skills-and-reference-material.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add some skills and reference material
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-30
 prNumber: '3402'
 ---

--- a/src/content/i-shipped/add-svelte-provider-documentation-and-metadata.mdx
+++ b/src/content/i-shipped/add-svelte-provider-documentation-and-metadata.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add Svelte provider documentation and metadata
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-05-19
 prNumber: '2246'
 ---

--- a/src/content/i-shipped/add-vanilla-code-snippets-everywhere.mdx
+++ b/src/content/i-shipped/add-vanilla-code-snippets-everywhere.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add vanilla code snippets everywhere
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-07
 prNumber: '3244'
 ---

--- a/src/content/i-shipped/add-w-full-to-the-pagefind-container-div.mdx
+++ b/src/content/i-shipped/add-w-full-to-the-pagefind-container-div.mdx
@@ -1,6 +1,6 @@
 ---
 summary: add w-full to the pagefind container div
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-06-09
 prNumber: '2467'
 ---

--- a/src/content/i-shipped/adjust-prominence-of-node-20-alert.mdx
+++ b/src/content/i-shipped/adjust-prominence-of-node-20-alert.mdx
@@ -1,6 +1,6 @@
 ---
 summary: adjust prominence of Node 20 alert
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-18
 prNumber: '2931'
 ---

--- a/src/content/i-shipped/agents-md-and-skill-files-into-newly-scaffolded-jazz-projects.mdx
+++ b/src/content/i-shipped/agents-md-and-skill-files-into-newly-scaffolded-jazz-projects.mdx
@@ -1,6 +1,6 @@
 ---
 summary: AGENTS.md and skill files into newly scaffolded Jazz projects
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-11
 prNumber: '3477'
 ---

--- a/src/content/i-shipped/agentsmd-files-for-jazz-starter-templates.mdx
+++ b/src/content/i-shipped/agentsmd-files-for-jazz-starter-templates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: AGENTS.md files for Jazz starter templates
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-22
 prNumber: '630'
 ---

--- a/src/content/i-shipped/aligned-vue-and-svelte-bindings-to-match-the-react-api.mdx
+++ b/src/content/i-shipped/aligned-vue-and-svelte-bindings-to-match-the-react-api.mdx
@@ -1,6 +1,6 @@
 ---
 summary: aligned Vue and Svelte bindings to match the React API
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-18
 prNumber: '351'
 ---

--- a/src/content/i-shipped/an-additional-section-to-our-performance-docs-documenting-batching-as-a-strategy-to-improve-performance.mdx
+++ b/src/content/i-shipped/an-additional-section-to-our-performance-docs-documenting-batching-as-a-strategy-to-improve-performance.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an additional section to our performance docs documenting batching as a
   strategy to improve performance
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-30
 prNumber: '3118'
 ---

--- a/src/content/i-shipped/an-advanced-internals-reference-page-for-the-docs.mdx
+++ b/src/content/i-shipped/an-advanced-internals-reference-page-for-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an advanced internals reference page for the docs
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-07
 prNumber: '449'
 ---

--- a/src/content/i-shipped/an-advent-of-jazz-banner-for-our-homepage-to-promote-the-initiative.mdx
+++ b/src/content/i-shipped/an-advent-of-jazz-banner-for-our-homepage-to-promote-the-initiative.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an 'Advent of Jazz' banner for our homepage to promote the initiative
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-01
 prNumber: '3226'
 ---

--- a/src/content/i-shipped/an-animated-diagram-showing-how-jazz-syncs-data-across-tiers-in-the-docs.mdx
+++ b/src/content/i-shipped/an-animated-diagram-showing-how-jazz-syncs-data-across-tiers-in-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an animated diagram showing how Jazz syncs data across tiers in the docs
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-15
 prNumber: '893'
 ---

--- a/src/content/i-shipped/an-enhanced-and-completely-reworked-version-of-the-subscriptions-and-deep-loading-article.mdx
+++ b/src/content/i-shipped/an-enhanced-and-completely-reworked-version-of-the-subscriptions-and-deep-loading-article.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an enhanced and completely reworked version of the Subscriptions & Deep
   Loading article
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-25
 prNumber: '2958'
 ---

--- a/src/content/i-shipped/an-enhancement-to-our-existing-server-side-rendering-agent-which-allows-it-to-be-used-outside-of-react.mdx
+++ b/src/content/i-shipped/an-enhancement-to-our-existing-server-side-rendering-agent-which-allows-it-to-be-used-outside-of-react.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an enhancement to our existing server-side rendering agent which allows it to
   be used outside of React
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-02
 prNumber: '2989'
 ---

--- a/src/content/i-shipped/an-example-for-clerk-integration-with-svelte.mdx
+++ b/src/content/i-shipped/an-example-for-clerk-integration-with-svelte.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an example for Clerk integration with Svelte
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-23
 prNumber: '3358'
 ---

--- a/src/content/i-shipped/an-expanded-local-first-auth-docs-section-with-internals-reference.mdx
+++ b/src/content/i-shipped/an-expanded-local-first-auth-docs-section-with-internals-reference.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an expanded local-first auth docs section with internals reference
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-24
 prNumber: '658'
 ---

--- a/src/content/i-shipped/an-extension-to-our-cryptography-docs-and-faq-clarifying-our-understanding-of-the-legal-status-of-jazz-s-encryption-algorithms.mdx
+++ b/src/content/i-shipped/an-extension-to-our-cryptography-docs-and-faq-clarifying-our-understanding-of-the-legal-status-of-jazz-s-encryption-algorithms.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an extension to our Cryptography docs and FAQ clarifying our understanding of
   the legal status of Jazz's encryption algorithms
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-30
 prNumber: '3122'
 ---

--- a/src/content/i-shipped/an-improvement-for-our-existing-code-group-component-s-copy-function.mdx
+++ b/src/content/i-shipped/an-improvement-for-our-existing-code-group-component-s-copy-function.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an improvement for our existing CodeGroup component's copy function
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-30
 prNumber: '2991'
 ---

--- a/src/content/i-shipped/an-improvement-to-our-docs-consolidating-our-various-bits-of-copy-for-getting-an-api-key-into-a-reusable-component.mdx
+++ b/src/content/i-shipped/an-improvement-to-our-docs-consolidating-our-various-bits-of-copy-for-getting-an-api-key-into-a-reusable-component.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an improvement to our docs, consolidating our various bits of copy for
   'getting an API key' into a reusable component
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-30
 prNumber: '2990'
 ---

--- a/src/content/i-shipped/an-improvement-to-our-homepage-which-lets-us-know-when-someone-abandons-a-search.mdx
+++ b/src/content/i-shipped/an-improvement-to-our-homepage-which-lets-us-know-when-someone-abandons-a-search.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an improvement to our homepage which lets us know when someone abandons a
   search
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-25
 prNumber: '3207'
 ---

--- a/src/content/i-shipped/an-interactive-app-id-generation-widget-for-the-docs.mdx
+++ b/src/content/i-shipped/an-interactive-app-id-generation-widget-for-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an interactive app ID generation widget for the docs
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-21
 prNumber: '606'
 ---

--- a/src/content/i-shipped/an-interactive-lens-diagram-to-the-migrations-documentation.mdx
+++ b/src/content/i-shipped/an-interactive-lens-diagram-to-the-migrations-documentation.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an interactive lens diagram to the migrations documentation
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-07
 prNumber: '801'
 ---

--- a/src/content/i-shipped/an-interactive-write-tier-diagram-for-the-jazz-docs.mdx
+++ b/src/content/i-shipped/an-interactive-write-tier-diagram-for-the-jazz-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an interactive write-tier diagram for the Jazz docs
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-22
 prNumber: '914'
 ---

--- a/src/content/i-shipped/an-mcp-server-that-lets-ai-assistants-search-the-jazz-docs.mdx
+++ b/src/content/i-shipped/an-mcp-server-that-lets-ai-assistants-search-the-jazz-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an MCP server that lets AI assistants search the Jazz docs
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-11
 prNumber: '3490'
 ---

--- a/src/content/i-shipped/an-option-for-the-svelte-provider-which-allows-users-to-pass-a-configuration-option-identifying-their-credentials.mdx
+++ b/src/content/i-shipped/an-option-for-the-svelte-provider-which-allows-users-to-pass-a-configuration-option-identifying-their-credentials.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an option for the Svelte provider which allows users to pass a configuration
   option identifying their credentials
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-29
 prNumber: '2984'
 ---

--- a/src/content/i-shipped/an-rss-feed-for-the-jazz-docs-blog.mdx
+++ b/src/content/i-shipped/an-rss-feed-for-the-jazz-docs-blog.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an RSS feed for the Jazz docs blog
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '841'
 ---

--- a/src/content/i-shipped/an-update-to-our-cli-tool-to-make-sure-that-the-correct-llms-full-txt-is-fetched-based-on-the-user-s-framework.mdx
+++ b/src/content/i-shipped/an-update-to-our-cli-tool-to-make-sure-that-the-correct-llms-full-txt-is-fetched-based-on-the-user-s-framework.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an update to our CLI tool to make sure that the correct llms-full.txt is
   fetched based on the user's framework
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-17
 prNumber: '3064'
 ---

--- a/src/content/i-shipped/an-update-to-our-cli-tool-which-adds-more-options.mdx
+++ b/src/content/i-shipped/an-update-to-our-cli-tool-which-adds-more-options.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an update to our CLI tool which adds more options
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-13
 prNumber: '3042'
 ---

--- a/src/content/i-shipped/an-update-to-our-cli-which-makes-sure-that-the-latest-docs-are-always-fetched-when-a-new-project-is-initialised.mdx
+++ b/src/content/i-shipped/an-update-to-our-cli-which-makes-sure-that-the-latest-docs-are-always-fetched-when-a-new-project-is-initialised.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an update to our CLI which makes sure that the latest docs are always fetched
   when a new project is initialised
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-09
 prNumber: '3017'
 ---

--- a/src/content/i-shipped/an-update-to-our-create-jazz-app-utility-to-ensure-that-only-the-appropriate-llms-full-txt-is-fetched.mdx
+++ b/src/content/i-shipped/an-update-to-our-create-jazz-app-utility-to-ensure-that-only-the-appropriate-llms-full-txt-is-fetched.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an update to our create-jazz-app utility to ensure that only the appropriate
   llms-full.txt is fetched
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-17
 prNumber: '3064'
 ---

--- a/src/content/i-shipped/an-update-to-our-docs-clarifying-that-jazz-deduplicates-loads-under-the-hood.mdx
+++ b/src/content/i-shipped/an-update-to-our-docs-clarifying-that-jazz-deduplicates-loads-under-the-hood.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an update to our docs clarifying that Jazz deduplicates loads under the hood
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-03
 prNumber: '3142'
 ---

--- a/src/content/i-shipped/an-update-to-our-docs-landing-page-with-a-minimal-example-of-how-to-use-jazz.mdx
+++ b/src/content/i-shipped/an-update-to-our-docs-landing-page-with-a-minimal-example-of-how-to-use-jazz.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an update to our docs landing page with a minimal example of how to use Jazz
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-12
 prNumber: '3215'
 ---

--- a/src/content/i-shipped/an-update-to-our-docs-showing-how-to-use-version-control-effectively-in-different-frameworks.mdx
+++ b/src/content/i-shipped/an-update-to-our-docs-showing-how-to-use-version-control-effectively-in-different-frameworks.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an update to our docs showing how to use version control effectively in
   different frameworks
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-12
 prNumber: '3263'
 ---

--- a/src/content/i-shipped/an-update-to-our-image-definition-docs-which-makes-it-more-maintainable.mdx
+++ b/src/content/i-shipped/an-update-to-our-image-definition-docs-which-makes-it-more-maintainable.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an update to our ImageDefinition docs which makes it more maintainable
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-21
 prNumber: '3077'
 ---

--- a/src/content/i-shipped/an-update-to-our-react-native-and-expo-example-apps-demonstrating-how-to-use-images.mdx
+++ b/src/content/i-shipped/an-update-to-our-react-native-and-expo-example-apps-demonstrating-how-to-use-images.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an update to our React Native and Expo example apps, demonstrating how to use
   images
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-13
 prNumber: '3167'
 ---

--- a/src/content/i-shipped/an-update-to-the-docs-clarifying-how-to-use-react-native-fast-encoder.mdx
+++ b/src/content/i-shipped/an-update-to-the-docs-clarifying-how-to-use-react-native-fast-encoder.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an update to the docs clarifying how to use React Native Fast Encoder
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-24
 prNumber: '3197'
 ---

--- a/src/content/i-shipped/an-update-to-the-docs-encouraging-users-to-sign-up-for-api-keys-rather-than-using-their-email-address.mdx
+++ b/src/content/i-shipped/an-update-to-the-docs-encouraging-users-to-sign-up-for-api-keys-rather-than-using-their-email-address.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an update to the docs encouraging users to sign up for API keys rather than
   using their email address
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-23
 prNumber: '2951'
 ---

--- a/src/content/i-shipped/an-update-to-the-svelte-invite-listener-so-that-it-listens-to-hash-change-events.mdx
+++ b/src/content/i-shipped/an-update-to-the-svelte-invite-listener-so-that-it-listens-to-hash-change-events.mdx
@@ -2,7 +2,7 @@
 summary: >-
   an update to the Svelte InviteListener so that it listens to hash change
   events.
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-12
 prNumber: "2911"
 ---

--- a/src/content/i-shipped/api-reference.mdx
+++ b/src/content/i-shipped/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 summary: aPI Reference
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-15
 prNumber: '3355'
 ---

--- a/src/content/i-shipped/assorted-example-app-updates.mdx
+++ b/src/content/i-shipped/assorted-example-app-updates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: assorted example app updates
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-22
 prNumber: '622'
 ---

--- a/src/content/i-shipped/async-example-fixes-and-browser-storage-eviction-guidance-in-the-docs.mdx
+++ b/src/content/i-shipped/async-example-fixes-and-browser-storage-eviction-guidance-in-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: async example fixes and browser storage eviction guidance in the docs
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-30
 prNumber: '708'
 ---

--- a/src/content/i-shipped/auto-reloading-of-nextjs-apps-when-the-schema-is-pushed.mdx
+++ b/src/content/i-shipped/auto-reloading-of-nextjs-apps-when-the-schema-is-pushed.mdx
@@ -1,6 +1,6 @@
 ---
 summary: auto-reloading of Next.js apps when the schema is pushed
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-05
 prNumber: '735'
 ---

--- a/src/content/i-shipped/autogenerate-better_auth_secret.mdx
+++ b/src/content/i-shipped/autogenerate-better_auth_secret.mdx
@@ -1,6 +1,6 @@
 ---
 summary: autogenerate BETTER_AUTH_SECRET
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-13
 prNumber: '3458'
 ---

--- a/src/content/i-shipped/automatic-browser-reloads-when-schema-changes-are-pushed-in-development.mdx
+++ b/src/content/i-shipped/automatic-browser-reloads-when-schema-changes-are-pushed-in-development.mdx
@@ -1,6 +1,6 @@
 ---
 summary: automatic browser reloads when schema changes are pushed in development
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-29
 prNumber: '715'
 ---

--- a/src/content/i-shipped/changeset-entries-for-two-bug-fixes.mdx
+++ b/src/content/i-shipped/changeset-entries-for-two-bug-fixes.mdx
@@ -1,6 +1,6 @@
 ---
 summary: changeset entries documenting two bug fixes
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-04-10
 prNumber: '3521'
 ---

--- a/src/content/i-shipped/clarify-polyfill-installation-instructions-in-react-native-setup.mdx
+++ b/src/content/i-shipped/clarify-polyfill-installation-instructions-in-react-native-setup.mdx
@@ -1,6 +1,6 @@
 ---
 summary: clarify polyfill installation instructions in React Native setup
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-04
 prNumber: '3240'
 ---

--- a/src/content/i-shipped/clarify-use-case-for-ensureloaded.mdx
+++ b/src/content/i-shipped/clarify-use-case-for-ensureloaded.mdx
@@ -1,6 +1,6 @@
 ---
 summary: clarify use case for ensureLoaded
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-29
 prNumber: '2971'
 ---

--- a/src/content/i-shipped/corrected-docstrings-for-database-operations.mdx
+++ b/src/content/i-shipped/corrected-docstrings-for-database-operations.mdx
@@ -1,6 +1,6 @@
 ---
 summary: corrected docstrings for database operations
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-05
 prNumber: '201'
 ---

--- a/src/content/i-shipped/deduplication-of-identical-permissions-bundle-publishes.mdx
+++ b/src/content/i-shipped/deduplication-of-identical-permissions-bundle-publishes.mdx
@@ -1,6 +1,6 @@
 ---
 summary: deduplication of identical permissions bundle publishes
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-28
 prNumber: '695'
 ---

--- a/src/content/i-shipped/deploy-time-warnings-for-missing-permission-policies.mdx
+++ b/src/content/i-shipped/deploy-time-warnings-for-missing-permission-policies.mdx
@@ -1,6 +1,6 @@
 ---
 summary: deploy-time warnings for missing permission policies
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-21
 prNumber: '603'
 ---

--- a/src/content/i-shipped/docsoptional-references.mdx
+++ b/src/content/i-shipped/docsoptional-references.mdx
@@ -1,6 +1,6 @@
 ---
 summary: docs/optional references
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-08-01
 prNumber: '2655'
 ---

--- a/src/content/i-shipped/docsquick-fixes.mdx
+++ b/src/content/i-shipped/docsquick-fixes.mdx
@@ -1,6 +1,6 @@
 ---
 summary: docs/quick fixes
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-05
 prNumber: '2869'
 ---

--- a/src/content/i-shipped/document-dealing-with-complex-getters.mdx
+++ b/src/content/i-shipped/document-dealing-with-complex-getters.mdx
@@ -1,6 +1,6 @@
 ---
 summary: document dealing with complex getters
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-13
 prNumber: '3280'
 ---

--- a/src/content/i-shipped/documentation-for-a-pattern-on-how-to-create-set-like-collections.mdx
+++ b/src/content/i-shipped/documentation-for-a-pattern-on-how-to-create-set-like-collections.mdx
@@ -1,6 +1,6 @@
 ---
 summary: documentation for a pattern on how to create set-like collections
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-13
 prNumber: '3178'
 ---

--- a/src/content/i-shipped/documentation-for-several-new-jazz-features-including-the-schema-hash-cli.mdx
+++ b/src/content/i-shipped/documentation-for-several-new-jazz-features-including-the-schema-hash-cli.mdx
@@ -1,6 +1,6 @@
 ---
 summary: documentation for several new Jazz features including the schema hash CLI
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-22
 prNumber: '916'
 ---

--- a/src/content/i-shipped/documentation-of-a-couple-of-type-script-options-that-jazz-doesn-t-work-well-with.mdx
+++ b/src/content/i-shipped/documentation-of-a-couple-of-type-script-options-that-jazz-doesn-t-work-well-with.mdx
@@ -2,7 +2,7 @@
 summary: >-
   documentation of a couple of TypeScript options that Jazz doesn't work well
   with.
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-25
 prNumber: '2966'
 ---

--- a/src/content/i-shipped/documentation-on-how-to-use-suspense-hooks.mdx
+++ b/src/content/i-shipped/documentation-on-how-to-use-suspense-hooks.mdx
@@ -1,6 +1,6 @@
 ---
 summary: documentation on how to use suspense hooks
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-06
 prNumber: '3331'
 ---

--- a/src/content/i-shipped/documentation-regarding-subscription-error-handling-using-on-unauthorized-and-on-unavailable.mdx
+++ b/src/content/i-shipped/documentation-regarding-subscription-error-handling-using-on-unauthorized-and-on-unavailable.mdx
@@ -2,7 +2,7 @@
 summary: >-
   documentation regarding subscription error handling using onUnauthorized and
   onUnavailable.
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-17
 prNumber: '3289'
 ---

--- a/src/content/i-shipped/dropping-an-unnecessary-fetch-polyfill-from-the-jazz-expo-integration.mdx
+++ b/src/content/i-shipped/dropping-an-unnecessary-fetch-polyfill-from-the-jazz-expo-integration.mdx
@@ -1,6 +1,6 @@
 ---
 summary: dropping an unnecessary fetch polyfill from the Jazz Expo integration
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-07
 prNumber: '812'
 ---

--- a/src/content/i-shipped/dropping-an-unnecessary-fetch-polyfill-from-the-jazz-expo-integration.mdx
+++ b/src/content/i-shipped/dropping-an-unnecessary-fetch-polyfill-from-the-jazz-expo-integration.mdx
@@ -1,6 +1,6 @@
 ---
 summary: dropping an unnecessary fetch polyfill from the Jazz Expo integration
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-07
 prNumber: '812'
 ---

--- a/src/content/i-shipped/dropping-nodejs-20-support-in-favour-of-nodejs-22.mdx
+++ b/src/content/i-shipped/dropping-nodejs-20-support-in-favour-of-nodejs-22.mdx
@@ -1,6 +1,6 @@
 ---
 summary: dropping Node.js 20 support in favour of Node.js 22
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-18
 prNumber: '892'
 ---

--- a/src/content/i-shipped/enable-dark-mode-support-for-minimal-to-do-list-example.mdx
+++ b/src/content/i-shipped/enable-dark-mode-support-for-minimal-to-do-list-example.mdx
@@ -1,6 +1,6 @@
 ---
 summary: enable dark mode support for minimal to-do list example
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-27
 prNumber: '3411'
 ---

--- a/src/content/i-shipped/enforce-sync-before-load-sveltekit-ssr.mdx
+++ b/src/content/i-shipped/enforce-sync-before-load-sveltekit-ssr.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a sync-before-navigate guard for SvelteKit SSR
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-19
 prNumber: '3464'
 ---

--- a/src/content/i-shipped/enhancements-to-our-llms-txt-files.mdx
+++ b/src/content/i-shipped/enhancements-to-our-llms-txt-files.mdx
@@ -1,6 +1,6 @@
 ---
 summary: enhancements to our llms.txt files
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-16
 prNumber: '3047'
 ---

--- a/src/content/i-shipped/ephemeral-storage-fallback-for-firefox-private-browsing.mdx
+++ b/src/content/i-shipped/ephemeral-storage-fallback-for-firefox-private-browsing.mdx
@@ -1,6 +1,6 @@
 ---
 summary: ephemeral storage fallback for Firefox private browsing
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-21
 prNumber: '605'
 ---

--- a/src/content/i-shipped/example-app-alignment-with-docs-and-permission-fixes.mdx
+++ b/src/content/i-shipped/example-app-alignment-with-docs-and-permission-fixes.mdx
@@ -1,6 +1,6 @@
 ---
 summary: example app alignment with docs and permission fixes
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-03
 prNumber: '451'
 ---

--- a/src/content/i-shipped/exists-subquery-support-in-policy-expressions.mdx
+++ b/src/content/i-shipped/exists-subquery-support-in-policy-expressions.mdx
@@ -1,6 +1,6 @@
 ---
 summary: EXISTS subquery support in policy expressions
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-05
 prNumber: '207'
 ---

--- a/src/content/i-shipped/expanded-scaffold-test-coverage-to-all-self-hosted-starters.mdx
+++ b/src/content/i-shipped/expanded-scaffold-test-coverage-to-all-self-hosted-starters.mdx
@@ -1,6 +1,6 @@
 ---
 summary: expanded scaffold test coverage to all self-hosted starters
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-27
 prNumber: '661'
 ---

--- a/src/content/i-shipped/experimental-clock-sync-for-clients-with-drifting-system-clocks.mdx
+++ b/src/content/i-shipped/experimental-clock-sync-for-clients-with-drifting-system-clocks.mdx
@@ -1,6 +1,6 @@
 ---
 summary: experimental clock sync for clients with drifting system clocks
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-04-18
 prNumber: '3524'
 ---

--- a/src/content/i-shipped/export-singlecofeedentry.mdx
+++ b/src/content/i-shipped/export-singlecofeedentry.mdx
@@ -1,6 +1,6 @@
 ---
 summary: export SingleCoFeedEntry
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-03
 prNumber: '3134'
 ---

--- a/src/content/i-shipped/extend-auth-quickstart-to-demonstrate-passkey-auth.mdx
+++ b/src/content/i-shipped/extend-auth-quickstart-to-demonstrate-passkey-auth.mdx
@@ -1,6 +1,6 @@
 ---
 summary: extend auth quickstart to demonstrate passkey auth
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-06
 prNumber: '3002'
 ---

--- a/src/content/i-shipped/fail-create-when-user-has-no-write-access-to-owner-group.mdx
+++ b/src/content/i-shipped/fail-create-when-user-has-no-write-access-to-owner-group.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   a guard that makes `.create()` fail when the user has no write access to the owner group
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-17
 prNumber: '3467'
 ---

--- a/src/content/i-shipped/fallback-support-for-framework-prefixed-environment-variables-in-the-jazz-cli.mdx
+++ b/src/content/i-shipped/fallback-support-for-framework-prefixed-environment-variables-in-the-jazz-cli.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fallback support for framework-prefixed environment variables in the Jazz CLI
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-27
 prNumber: '669'
 ---

--- a/src/content/i-shipped/feedback-options-for-folks-using-our-docs-to-vote-on-whether-they-found-our-content-helpful-or-not.mdx
+++ b/src/content/i-shipped/feedback-options-for-folks-using-our-docs-to-vote-on-whether-they-found-our-content-helpful-or-not.mdx
@@ -2,7 +2,7 @@
 summary: >-
   feedback options for folks using our docs to vote on whether they found our
   content helpful or not
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-25
 prNumber: '3206'
 ---

--- a/src/content/i-shipped/file-and-blob-storage-for-the-wequencer-example.mdx
+++ b/src/content/i-shipped/file-and-blob-storage-for-the-wequencer-example.mdx
@@ -1,6 +1,6 @@
 ---
 summary: file and blob storage for the Wequencer example
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-01
 prNumber: '355'
 ---

--- a/src/content/i-shipped/filter-all-the-code-snippets-to-show-only-the-framework-relevant-snippets.mdx
+++ b/src/content/i-shipped/filter-all-the-code-snippets-to-show-only-the-framework-relevant-snippets.mdx
@@ -1,6 +1,6 @@
 ---
 summary: filter all the code snippets to show only the framework relevant snippets
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-14
 prNumber: '3048'
 ---

--- a/src/content/i-shipped/first-class-svelte-support-for-better-auth.mdx
+++ b/src/content/i-shipped/first-class-svelte-support-for-better-auth.mdx
@@ -1,6 +1,6 @@
 ---
 summary: first class Svelte support for Better Auth
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-08
 prNumber: '3285'
 ---

--- a/src/content/i-shipped/fix-3186.mdx
+++ b/src/content/i-shipped/fix-3186.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   fix #3186
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-18
 prNumber: '3187'
 ---

--- a/src/content/i-shipped/fix-build-issues.mdx
+++ b/src/content/i-shipped/fix-build-issues.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fix build issues
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-07
 prNumber: '3009'
 ---

--- a/src/content/i-shipped/fix-chat-demo.mdx
+++ b/src/content/i-shipped/fix-chat-demo.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fix chat demo
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-15
 prNumber: '3279'
 ---

--- a/src/content/i-shipped/fix-expo-placeholders.mdx
+++ b/src/content/i-shipped/fix-expo-placeholders.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fix expo placeholders
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-16
 prNumber: '3375'
 ---

--- a/src/content/i-shipped/fix-homepage-build-issues.mdx
+++ b/src/content/i-shipped/fix-homepage-build-issues.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fix homepage build issues
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-13
 prNumber: '3179'
 ---

--- a/src/content/i-shipped/fix-http-api-link-in-inboxmdx-fixes-2687.mdx
+++ b/src/content/i-shipped/fix-http-api-link-in-inboxmdx-fixes-2687.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   fix HTTP API link in inbox.mdx. Fixes #2687
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-08-01
 prNumber: '2689'
 ---

--- a/src/content/i-shipped/fix-issue-when-code-sample-is-formatted.mdx
+++ b/src/content/i-shipped/fix-issue-when-code-sample-is-formatted.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fix issue when code sample is formatted
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-24
 prNumber: '3184'
 ---

--- a/src/content/i-shipped/fix-missing-in-template-literal.mdx
+++ b/src/content/i-shipped/fix-missing-in-template-literal.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fix missing $ in template literal
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-05-16
 prNumber: '2261'
 ---

--- a/src/content/i-shipped/fix-missing-link-to-the-betterauth-database-adapter-doc.mdx
+++ b/src/content/i-shipped/fix-missing-link-to-the-betterauth-database-adapter-doc.mdx
@@ -1,6 +1,6 @@
 ---
 summary: fix missing link to the BetterAuth Database Adapter doc
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-15
 prNumber: '3055'
 ---

--- a/src/content/i-shipped/fix-tojson-serialisation-for-corecord.mdx
+++ b/src/content/i-shipped/fix-tojson-serialisation-for-corecord.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   fix `toJSON()` serialisation for `co.record`
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-07
 prNumber: '3444'
 ---

--- a/src/content/i-shipped/fixes-for-our-end-to-end-tests-which-were-failing-in-ci-due-to-incorrect-imports-caused-by-our-test-runners-upgrading-slowly-to-node-22-19.mdx
+++ b/src/content/i-shipped/fixes-for-our-end-to-end-tests-which-were-failing-in-ci-due-to-incorrect-imports-caused-by-our-test-runners-upgrading-slowly-to-node-22-19.mdx
@@ -2,7 +2,7 @@
 summary: >-
   fixes for our end-to-end tests which were failing in CI due to incorrect
   imports caused by our test runners upgrading slowly to Node 22.19
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-06
 prNumber: '3003'
 ---

--- a/src/content/i-shipped/fixreact-native-clear-stored-session-id-when-clearing-user-credentials.mdx
+++ b/src/content/i-shipped/fixreact-native-clear-stored-session-id-when-clearing-user-credentials.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   a fix to clear the stored session ID when clearing user credentials in React Native
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-19
 prNumber: '3470'
 ---

--- a/src/content/i-shipped/from-implementations-and-a-row-input-macro.mdx
+++ b/src/content/i-shipped/from-implementations-and-a-row-input-macro.mdx
@@ -1,6 +1,6 @@
 ---
 summary: From implementations and a row_input! macro
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-08
 prNumber: '475'
 ---

--- a/src/content/i-shipped/granular-reactivity-for-svelte-and-vue.mdx
+++ b/src/content/i-shipped/granular-reactivity-for-svelte-and-vue.mdx
@@ -1,6 +1,6 @@
 ---
 summary: granular reactivity for Svelte and Vue
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-27
 prNumber: '393'
 ---

--- a/src/content/i-shipped/grey-out-quickstarts-for-rn.mdx
+++ b/src/content/i-shipped/grey-out-quickstarts-for-rn.mdx
@@ -1,6 +1,6 @@
 ---
 summary: grey out quickstarts for RN
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-22
 prNumber: '3088'
 ---

--- a/src/content/i-shipped/guides-quickstarts-and-framework-patterns-for-the-docs.mdx
+++ b/src/content/i-shipped/guides-quickstarts-and-framework-patterns-for-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: guides, quickstarts, and framework patterns for the docs
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-07
 prNumber: '236'
 ---

--- a/src/content/i-shipped/hotfix-for-homepage.mdx
+++ b/src/content/i-shipped/hotfix-for-homepage.mdx
@@ -1,6 +1,6 @@
 ---
 summary: hotfix for homepage
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-09
 prNumber: '3028'
 ---

--- a/src/content/i-shipped/improve-showcase-display-on-smaller-screens.mdx
+++ b/src/content/i-shipped/improve-showcase-display-on-smaller-screens.mdx
@@ -1,6 +1,6 @@
 ---
 summary: improve showcase display on smaller screens
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-09
 prNumber: '3257'
 ---

--- a/src/content/i-shipped/improved-spinner-ux-and-dotenv-support-for-the-jazz-tools-cli.mdx
+++ b/src/content/i-shipped/improved-spinner-ux-and-dotenv-support-for-the-jazz-tools-cli.mdx
@@ -1,6 +1,6 @@
 ---
 summary: improved spinner UX and dotenv support for the jazz-tools CLI
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-29
 prNumber: '706'
 ---

--- a/src/content/i-shipped/improved-type-checking-for-vanilla-snippets.mdx
+++ b/src/content/i-shipped/improved-type-checking-for-vanilla-snippets.mdx
@@ -1,6 +1,6 @@
 ---
 summary: improved type-checking for vanilla snippets
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-24
 prNumber: '3194'
 ---

--- a/src/content/i-shipped/improvements-to-our-react-native-and-expo-documentation-added-a-polyfills-module-to-jazz.mdx
+++ b/src/content/i-shipped/improvements-to-our-react-native-and-expo-documentation-added-a-polyfills-module-to-jazz.mdx
@@ -2,7 +2,7 @@
 summary: >-
   improvements to our React Native and Expo documentation, added a 'polyfills'
   module to Jazz
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-02
 prNumber: '3218'
 ---

--- a/src/content/i-shipped/increase-z-index-of-aoj-banner.mdx
+++ b/src/content/i-shipped/increase-z-index-of-aoj-banner.mdx
@@ -1,6 +1,6 @@
 ---
 summary: increase Z-index of AoJ banner
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-01
 prNumber: '3229'
 ---

--- a/src/content/i-shipped/jwks-rotation-support-for-self-hosted-servers.mdx
+++ b/src/content/i-shipped/jwks-rotation-support-for-self-hosted-servers.mdx
@@ -1,6 +1,6 @@
 ---
 summary: JWKS rotation support for self-hosted servers
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-20
 prNumber: '340'
 ---

--- a/src/content/i-shipped/localfirstauth-framework-hooks-in-the-jazz-starter-templates.mdx
+++ b/src/content/i-shipped/localfirstauth-framework-hooks-in-the-jazz-starter-templates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: LocalFirstAuth framework hooks in the Jazz starter templates
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-18
 prNumber: '894'
 ---

--- a/src/content/i-shipped/make-latency-bar-red-if-theres-an-ongoing-outage.mdx
+++ b/src/content/i-shipped/make-latency-bar-red-if-theres-an-ongoing-outage.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   make latency bar red if there's an ongoing outage
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-09
 prNumber: '2877'
 ---

--- a/src/content/i-shipped/markdown-serving-for-ai-agents-from-the-jazz-docs.mdx
+++ b/src/content/i-shipped/markdown-serving-for-ai-agents-from-the-jazz-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: markdown serving for AI agents from the Jazz docs
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '856'
 ---

--- a/src/content/i-shipped/migration-of-example-code-to-row-input-macro.mdx
+++ b/src/content/i-shipped/migration-of-example-code-to-row-input-macro.mdx
@@ -1,6 +1,6 @@
 ---
 summary: migration of example code to row_input! macro
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-08
 prNumber: '485'
 ---

--- a/src/content/i-shipped/move-codecs-under-schema-and-republish-link.mdx
+++ b/src/content/i-shipped/move-codecs-under-schema-and-republish-link.mdx
@@ -1,6 +1,6 @@
 ---
 summary: move codecs under schema and republish link
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-11-04
 prNumber: '3137'
 ---

--- a/src/content/i-shipped/new-apps-to-the-jazz-showcase-and-redesigned-the-layout-to-a-card-grid.mdx
+++ b/src/content/i-shipped/new-apps-to-the-jazz-showcase-and-redesigned-the-layout-to-a-card-grid.mdx
@@ -1,6 +1,6 @@
 ---
 summary: new apps to the Jazz showcase and redesigned the layout to a card grid
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-26
 prNumber: '3475'
 ---

--- a/src/content/i-shipped/options-object-support-for-svelte-querysubscription.mdx
+++ b/src/content/i-shipped/options-object-support-for-svelte-querysubscription.mdx
@@ -1,6 +1,6 @@
 ---
 summary: options object support for Svelte QuerySubscription
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-07
 prNumber: '231'
 ---

--- a/src/content/i-shipped/ordered-transport-batching-for-sync.mdx
+++ b/src/content/i-shipped/ordered-transport-batching-for-sync.mdx
@@ -1,6 +1,6 @@
 ---
 summary: ordered transport batching for sync
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-12
 prNumber: '284'
 ---

--- a/src/content/i-shipped/passphrase-and-passkey-backup-restore-ui-for-starters.mdx
+++ b/src/content/i-shipped/passphrase-and-passkey-backup-restore-ui-for-starters.mdx
@@ -1,6 +1,6 @@
 ---
 summary: passphrase and passkey backup/restore UI for starters
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-20
 prNumber: '584'
 ---

--- a/src/content/i-shipped/per-package-progress-on-the-create-jazz-dependency-spinner.mdx
+++ b/src/content/i-shipped/per-package-progress-on-the-create-jazz-dependency-spinner.mdx
@@ -1,6 +1,6 @@
 ---
 summary: per-package progress on the create-jazz dependency spinner
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-23
 prNumber: '655'
 ---

--- a/src/content/i-shipped/post-015-docs-fixes.mdx
+++ b/src/content/i-shipped/post-015-docs-fixes.mdx
@@ -1,6 +1,6 @@
 ---
 summary: post 0.15 docs fixes
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-06-24
 prNumber: '2570'
 ---

--- a/src/content/i-shipped/pruned-tests-in-the-moon-lander-example.mdx
+++ b/src/content/i-shipped/pruned-tests-in-the-moon-lander-example.mdx
@@ -1,6 +1,6 @@
 ---
 summary: pruned tests in the moon-lander example
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-17
 prNumber: '545'
 ---

--- a/src/content/i-shipped/quickstart-guides-for-react-svelte-and-server-workers-for-jazz.mdx
+++ b/src/content/i-shipped/quickstart-guides-for-react-svelte-and-server-workers-for-jazz.mdx
@@ -1,6 +1,6 @@
 ---
 summary: quickstart guides for React, Svelte and Server Workers for Jazz
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-18
 prNumber: '2824'
 ---

--- a/src/content/i-shipped/react-spa-starter-variants-and-create-jazz-provisioning.mdx
+++ b/src/content/i-shipped/react-spa-starter-variants-and-create-jazz-provisioning.mdx
@@ -1,6 +1,6 @@
 ---
 summary: React SPA starter variants and create-jazz provisioning
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-21
 prNumber: '592'
 ---

--- a/src/content/i-shipped/reactive-localfirstauth-support-for-svelte-and-vue.mdx
+++ b/src/content/i-shipped/reactive-localfirstauth-support-for-svelte-and-vue.mdx
@@ -1,6 +1,6 @@
 ---
 summary: reactive LocalFirstAuth support for Svelte and Vue
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-18
 prNumber: '879'
 ---

--- a/src/content/i-shipped/real-urls-for-placeholder-links-in-a-blog-post.mdx
+++ b/src/content/i-shipped/real-urls-for-placeholder-links-in-a-blog-post.mdx
@@ -1,6 +1,6 @@
 ---
 summary: real URLs for placeholder links in a blog post
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-22
 prNumber: '651'
 ---

--- a/src/content/i-shipped/reliable-end-to-end-test-setup-for-svelte.mdx
+++ b/src/content/i-shipped/reliable-end-to-end-test-setup-for-svelte.mdx
@@ -1,6 +1,6 @@
 ---
 summary: reliable end-to-end test setup for Svelte
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-02
 prNumber: '186'
 ---

--- a/src/content/i-shipped/removal-of-stale-jwt-claims-from-starter-templates.mdx
+++ b/src/content/i-shipped/removal-of-stale-jwt-claims-from-starter-templates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: removal of stale JWT claims from starter templates
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-24
 prNumber: '660'
 ---

--- a/src/content/i-shipped/remove-await-from-create-calls-in-code-examples.mdx
+++ b/src/content/i-shipped/remove-await-from-create-calls-in-code-examples.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   remove `await` from `create` calls in code examples
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-13
 prNumber: '3456'
 ---

--- a/src/content/i-shipped/remove-manuscriptsprosemirror-recreate-steps-and-replace-with-local.mdx
+++ b/src/content/i-shipped/remove-manuscriptsprosemirror-recreate-steps-and-replace-with-local.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   remove `@manuscripts/prosemirror-recreate-steps` and replace with local implementation
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-02-13
 prNumber: '3459'
 ---

--- a/src/content/i-shipped/remove-unnecessary-consolelog.mdx
+++ b/src/content/i-shipped/remove-unnecessary-consolelog.mdx
@@ -1,6 +1,6 @@
 ---
 summary: remove unnecessary console.log
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-06-02
 prNumber: '2367'
 ---

--- a/src/content/i-shipped/reorganised-docs-to-split-deployment-configuration-from-server-setup.mdx
+++ b/src/content/i-shipped/reorganised-docs-to-split-deployment-configuration-from-server-setup.mdx
@@ -1,6 +1,6 @@
 ---
 summary: reorganised docs to split deployment configuration from server setup
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-03-11
 prNumber: '3461'
 ---

--- a/src/content/i-shipped/replace-delete-local-data-modal-with-a-reusable-component.mdx
+++ b/src/content/i-shipped/replace-delete-local-data-modal-with-a-reusable-component.mdx
@@ -1,6 +1,6 @@
 ---
 summary: replace delete local data modal with a reusable component
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-10
 prNumber: '2897'
 ---

--- a/src/content/i-shipped/restructure-the-docs-following-the-nav-menu-updates.mdx
+++ b/src/content/i-shipped/restructure-the-docs-following-the-nav-menu-updates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: restructure the docs following the nav menu updates
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-20
 prNumber: '3071'
 ---

--- a/src/content/i-shipped/rune-based-test-infrastructure-for-svelte.mdx
+++ b/src/content/i-shipped/rune-based-test-infrastructure-for-svelte.mdx
@@ -1,6 +1,6 @@
 ---
 summary: rune-based test infrastructure for Svelte
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-26
 prNumber: '387'
 ---

--- a/src/content/i-shipped/rust-examples-for-the-files-and-blobs-docs-page.mdx
+++ b/src/content/i-shipped/rust-examples-for-the-files-and-blobs-docs-page.mdx
@@ -1,6 +1,6 @@
 ---
 summary: Rust examples for the files-and-blobs docs page
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-08
 prNumber: '474'
 ---

--- a/src/content/i-shipped/serialize-secretseed-as-array-in-auth-header.mdx
+++ b/src/content/i-shipped/serialize-secretseed-as-array-in-auth-header.mdx
@@ -1,6 +1,6 @@
 ---
 summary: serialize secretSeed as array in auth header
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-01-12
 prNumber: '3352'
 ---

--- a/src/content/i-shipped/some-extensive-changes-to-our-navigation-menu.mdx
+++ b/src/content/i-shipped/some-extensive-changes-to-our-navigation-menu.mdx
@@ -1,6 +1,6 @@
 ---
 summary: some extensive changes to our navigation menu
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-07
 prNumber: '2930'
 ---

--- a/src/content/i-shipped/support-for-getter-functions-in-svelte-querysubscription.mdx
+++ b/src/content/i-shipped/support-for-getter-functions-in-svelte-querysubscription.mdx
@@ -1,6 +1,6 @@
 ---
 summary: support for getter functions in Svelte QuerySubscription
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-27
 prNumber: '672'
 ---

--- a/src/content/i-shipped/support-for-real-float-column-types.mdx
+++ b/src/content/i-shipped/support-for-real-float-column-types.mdx
@@ -1,6 +1,6 @@
 ---
 summary: support for Real (float) column types
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-02-25
 prNumber: '118'
 ---

--- a/src/content/i-shipped/svelte-5-bindings-for-jazz-tools.mdx
+++ b/src/content/i-shipped/svelte-5-bindings-for-jazz-tools.mdx
@@ -1,6 +1,6 @@
 ---
 summary: Svelte 5 bindings for jazz-tools
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-02-26
 prNumber: '145'
 ---

--- a/src/content/i-shipped/test-failure-guidance-for-ai-agents.mdx
+++ b/src/content/i-shipped/test-failure-guidance-for-ai-agents.mdx
@@ -1,6 +1,6 @@
 ---
 summary: test failure guidance for AI agents in CLAUDE.md
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-22
 prNumber: '627'
 ---

--- a/src/content/i-shipped/the-create-jazz-cli-scaffolder.mdx
+++ b/src/content/i-shipped/the-create-jazz-cli-scaffolder.mdx
@@ -1,6 +1,6 @@
 ---
 summary: the create-jazz CLI scaffolder
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-20
 prNumber: '524'
 ---

--- a/src/content/i-shipped/three-new-typescript-only-starter-templates.mdx
+++ b/src/content/i-shipped/three-new-typescript-only-starter-templates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: three new TypeScript-only starter templates
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '847'
 ---

--- a/src/content/i-shipped/three-new-typescript-only-starter-templates.mdx
+++ b/src/content/i-shipped/three-new-typescript-only-starter-templates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: three new TypeScript-only starter templates
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2026-05-13
 prNumber: '847'
 ---

--- a/src/content/i-shipped/two-quickstart-guides-one-for-authentication-and-one-for-groups-and-permissions.mdx
+++ b/src/content/i-shipped/two-quickstart-guides-one-for-authentication-and-one-for-groups-and-permissions.mdx
@@ -1,6 +1,6 @@
 ---
 summary: two quickstart guides, one for authentication and one for groups & permissions
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-30
 prNumber: '2914'
 ---

--- a/src/content/i-shipped/update-chat-example-to-use-jazz-for-message-and-image-handling.mdx
+++ b/src/content/i-shipped/update-chat-example-to-use-jazz-for-message-and-image-handling.mdx
@@ -1,6 +1,6 @@
 ---
 summary: update chat example to use $jazz for message and image handling
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-08
 prNumber: '2885'
 ---

--- a/src/content/i-shipped/update-examples-to-use-environment-variable-for-api-key.mdx
+++ b/src/content/i-shipped/update-examples-to-use-environment-variable-for-api-key.mdx
@@ -1,6 +1,6 @@
 ---
 summary: update examples to use environment variable for API key
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-12
 prNumber: '2892'
 ---

--- a/src/content/i-shipped/update-readme-and-gitignore-files.mdx
+++ b/src/content/i-shipped/update-readme-and-gitignore-files.mdx
@@ -1,6 +1,6 @@
 ---
 summary: update README and .gitignore files
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-06-12
 prNumber: '2513'
 ---

--- a/src/content/i-shipped/update-readme-files-to-reflect-changes-in-local-sync-server-setup.mdx
+++ b/src/content/i-shipped/update-readme-files-to-reflect-changes-in-local-sync-server-setup.mdx
@@ -1,6 +1,6 @@
 ---
 summary: update README files to reflect changes in local sync server setup
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-06-05
 prNumber: '2444'
 ---

--- a/src/content/i-shipped/update-svelte-starter.mdx
+++ b/src/content/i-shipped/update-svelte-starter.mdx
@@ -1,6 +1,6 @@
 ---
 summary: update Svelte starter
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-12
 prNumber: '2913'
 ---

--- a/src/content/i-shipped/update-svelte-testing-path-in-packagejson.mdx
+++ b/src/content/i-shipped/update-svelte-testing-path-in-packagejson.mdx
@@ -1,6 +1,6 @@
 ---
 summary: update Svelte testing path in package.json
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-08-25
 prNumber: '2810'
 ---

--- a/src/content/i-shipped/update-useframework-to-respond-to-tab_change_events-emitted-on-the-window.mdx
+++ b/src/content/i-shipped/update-useframework-to-respond-to-tab_change_events-emitted-on-the-window.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   update `useFramework` to respond to TAB_CHANGE_EVENTs emitted on the window
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-09-18
 prNumber: '2933'
 ---

--- a/src/content/i-shipped/updated-dev-docs-reflecting-the-build-less-workflow.mdx
+++ b/src/content/i-shipped/updated-dev-docs-reflecting-the-build-less-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 summary: updated dev docs reflecting the build-less workflow
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-01
 prNumber: '441'
 ---

--- a/src/content/i-shipped/updates-to-the-quickstart-guide-for-authentication-which-illustrates-how-to-add-a-recovery-key-using-passphrase-authentication.mdx
+++ b/src/content/i-shipped/updates-to-the-quickstart-guide-for-authentication-which-illustrates-how-to-add-a-recovery-key-using-passphrase-authentication.mdx
@@ -2,7 +2,7 @@
 summary: >-
   updates to the quickstart guide for authentication which illustrates how to
   add a recovery key using passphrase authentication
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-06
 prNumber: '3003'
 ---

--- a/src/content/i-shipped/updates-to-the-way-we-generate-our-docs-export-for-ll-ms-to-consume.mdx
+++ b/src/content/i-shipped/updates-to-the-way-we-generate-our-docs-export-for-ll-ms-to-consume.mdx
@@ -1,6 +1,6 @@
 ---
 summary: updates to the way we generate our docs export for LLMs to consume
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-10-12
 prNumber: '3018'
 ---

--- a/src/content/i-shipped/use-hash-fragment-in-invite-url-example.mdx
+++ b/src/content/i-shipped/use-hash-fragment-in-invite-url-example.mdx
@@ -1,6 +1,6 @@
 ---
 summary: use hash fragment in invite URL example
-repo: garden-co/jazz
+repo: garden-co/classic-jazz
 mergeDate: 2025-12-12
 prNumber: '3258'
 ---

--- a/src/content/i-shipped/vite-config-hooks-for-worker-format-and-optimizedeps.mdx
+++ b/src/content/i-shipped/vite-config-hooks-for-worker-format-and-optimizedeps.mdx
@@ -1,6 +1,6 @@
 ---
 summary: Vite config hooks for worker format and optimizeDeps
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-04-22
 prNumber: '632'
 ---

--- a/src/content/i-shipped/wequencer-a-collaborative-real-time-music-sequencer-example.mdx
+++ b/src/content/i-shipped/wequencer-a-collaborative-real-time-music-sequencer-example.mdx
@@ -1,7 +1,7 @@
 ---
 summary: >-
   Wequencer, a collaborative real-time music sequencer example
-repo: garden-co/jazz2
+repo: garden-co/jazz
 mergeDate: 2026-03-02
 prNumber: '190'
 ---


### PR DESCRIPTION
## Summary
- The `jazz` repo was renamed to `classic-jazz`, and `jazz2` was renamed to `jazz`. This broke 241 i-shipped links.
- Rewrites `repo: garden-co/jazz` → `repo: garden-co/classic-jazz` (162 entries) and `repo: garden-co/jazz2` → `repo: garden-co/jazz` (74 entries).
- Corrects 5 post-rename entries that already used the new `garden-co/jazz` name and got swept up in the bulk rewrite.
- Fixes a stray `#` in `prNumber: '#3274'` for the Web Locks API entry.

## Validation
All 241 changed entries were verified against the GitHub API; every link returns HTTP 200. Two unrelated pre-existing 404s remain (`spicygolf/spicy#333`, `bradleytaunt/1mb-club#839`) — left for a separate cleanup.

## Test plan
- [ ] Visit `/i-shipped` locally; spot-check a handful of links open the right PRs
- [ ] Build passes on Vercel preview