### PR TITLE
Re-route 23 misrouted jazz links and drop 2 broken entries

### DIFF
--- a/src/content/i-shipped/a-custom-declarative-diagram-engine-to-replace-mermaid-in-the-docs.mdx
+++ b/src/content/i-shipped/a-custom-declarative-diagram-engine-to-replace-mermaid-in-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a custom declarative diagram engine to replace Mermaid in the Jazz docs
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-22
 prNumber: '912'
 ---

--- a/src/content/i-shipped/a-dashboard-link-to-the-jazz-docs-site-navigation.mdx
+++ b/src/content/i-shipped/a-dashboard-link-to-the-jazz-docs-site-navigation.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a Dashboard link to the Jazz docs site navigation
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-15
 prNumber: '895'
 ---

--- a/src/content/i-shipped/a-fix-for-a-react-native-ui-freeze-caused-by-synchronous-database-queries.mdx
+++ b/src/content/i-shipped/a-fix-for-a-react-native-ui-freeze-caused-by-synchronous-database-queries.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a React Native UI freeze caused by synchronous database queries
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-06
 prNumber: '800'
 ---

--- a/src/content/i-shipped/a-fix-for-a-stale-repository-reference-in-the-create-jazz-scaffolding-tool.mdx
+++ b/src/content/i-shipped/a-fix-for-a-stale-repository-reference-in-the-create-jazz-scaffolding-tool.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for a stale repository reference in the create-jazz scaffolding tool
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-04
 prNumber: '775'
 ---

--- a/src/content/i-shipped/a-fix-for-deep-query-subscriptions-losing-reactivity.mdx
+++ b/src/content/i-shipped/a-fix-for-deep-query-subscriptions-losing-reactivity.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for deep query subscriptions losing reactivity
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '861'
 ---

--- a/src/content/i-shipped/a-fix-for-the-browser-benchmark-suite-being-hidden-from-ci.mdx
+++ b/src/content/i-shipped/a-fix-for-the-browser-benchmark-suite-being-hidden-from-ci.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for the browser benchmark suite being hidden from CI
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '863'
 ---

--- a/src/content/i-shipped/a-fix-for-the-jazz-tools-cli-silently-doing-nothing-when-run-through-pnpm.mdx
+++ b/src/content/i-shipped/a-fix-for-the-jazz-tools-cli-silently-doing-nothing-when-run-through-pnpm.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a fix for the jazz-tools CLI silently doing nothing when run through pnpm
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-18
 prNumber: '891'
 ---

--- a/src/content/i-shipped/a-rebuilt-world-tour-example-with-a-custom-globe-and-vue-tests.mdx
+++ b/src/content/i-shipped/a-rebuilt-world-tour-example-with-a-custom-globe-and-vue-tests.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a rebuilt world-tour example with a custom globe and Vue tests
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '814'
 ---

--- a/src/content/i-shipped/a-security-fix-for-unauthenticated-oom-via-websocket-handshake-decompression.mdx
+++ b/src/content/i-shipped/a-security-fix-for-unauthenticated-oom-via-websocket-handshake-decompression.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a security fix for unauthenticated OOM via WebSocket handshake decompression
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-28
 prNumber: '955'
 ---

--- a/src/content/i-shipped/a-testing-infrastructure-cleanup-for-the-chat-react-example-app.mdx
+++ b/src/content/i-shipped/a-testing-infrastructure-cleanup-for-the-chat-react-example-app.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a testing infrastructure cleanup for the chat-react example app
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-01
 prNumber: '739'
 ---

--- a/src/content/i-shipped/a-type-level-fix-for-hopto-destination-row-type-inference.mdx
+++ b/src/content/i-shipped/a-type-level-fix-for-hopto-destination-row-type-inference.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a type-level fix for hopTo destination row type inference
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-14
 prNumber: '877'
 ---

--- a/src/content/i-shipped/a-typescript-type-fix-for-the-sveltekit-plugin-in-strict-mode.mdx
+++ b/src/content/i-shipped/a-typescript-type-fix-for-the-sveltekit-plugin-in-strict-mode.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a TypeScript type fix for the SvelteKit plugin in strict mode
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '857'
 ---

--- a/src/content/i-shipped/a-vue-3-todo-example-for-jazz.mdx
+++ b/src/content/i-shipped/a-vue-3-todo-example-for-jazz.mdx
@@ -1,6 +1,6 @@
 ---
 summary: a Vue 3 todo example for Jazz
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-18
 prNumber: '878'
 ---

--- a/src/content/i-shipped/an-animated-diagram-showing-how-jazz-syncs-data-across-tiers-in-the-docs.mdx
+++ b/src/content/i-shipped/an-animated-diagram-showing-how-jazz-syncs-data-across-tiers-in-the-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an animated diagram showing how Jazz syncs data across tiers in the docs
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-15
 prNumber: '893'
 ---

--- a/src/content/i-shipped/an-interactive-lens-diagram-to-the-migrations-documentation.mdx
+++ b/src/content/i-shipped/an-interactive-lens-diagram-to-the-migrations-documentation.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an interactive lens diagram to the migrations documentation
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-07
 prNumber: '801'
 ---

--- a/src/content/i-shipped/an-interactive-write-tier-diagram-for-the-jazz-docs.mdx
+++ b/src/content/i-shipped/an-interactive-write-tier-diagram-for-the-jazz-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an interactive write-tier diagram for the Jazz docs
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-22
 prNumber: '914'
 ---

--- a/src/content/i-shipped/an-rss-feed-for-the-jazz-docs-blog.mdx
+++ b/src/content/i-shipped/an-rss-feed-for-the-jazz-docs-blog.mdx
@@ -1,6 +1,6 @@
 ---
 summary: an RSS feed for the Jazz docs blog
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '841'
 ---

--- a/src/content/i-shipped/auto-reloading-of-nextjs-apps-when-the-schema-is-pushed.mdx
+++ b/src/content/i-shipped/auto-reloading-of-nextjs-apps-when-the-schema-is-pushed.mdx
@@ -1,6 +1,6 @@
 ---
 summary: auto-reloading of Next.js apps when the schema is pushed
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-05
 prNumber: '735'
 ---

--- a/src/content/i-shipped/claude-improvements.mdx
+++ b/src/content/i-shipped/claude-improvements.mdx
@@ -1,7 +1,0 @@
----
-summary: claude improvements
-repo: spicygolf/spicy
-mergeDate: 2026-01-17
-prNumber: '333'
----
-Spicy Golf is an online golf game built with Jazz. I updated the AI assistant instructions (used by Claude for code generation) to match Jazz's latest patterns and best practices, so that AI-generated code suggestions for the project stay accurate and up to date.

--- a/src/content/i-shipped/create-traistcoukmd.mdx
+++ b/src/content/i-shipped/create-traistcoukmd.mdx
@@ -1,7 +1,0 @@
----
-summary: create traist.co.uk.md
-repo: bradleytaunt/1mb-club
-mergeDate: 2021-12-02
-prNumber: '839'
----
-The 1MB Club is a curated list of websites that are under 1MB in total size. I submitted traist.co.uk to be included in the collection.

--- a/src/content/i-shipped/documentation-for-several-new-jazz-features-including-the-schema-hash-cli.mdx
+++ b/src/content/i-shipped/documentation-for-several-new-jazz-features-including-the-schema-hash-cli.mdx
@@ -1,6 +1,6 @@
 ---
 summary: documentation for several new Jazz features including the schema hash CLI
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-22
 prNumber: '916'
 ---

--- a/src/content/i-shipped/dropping-nodejs-20-support-in-favour-of-nodejs-22.mdx
+++ b/src/content/i-shipped/dropping-nodejs-20-support-in-favour-of-nodejs-22.mdx
@@ -1,6 +1,6 @@
 ---
 summary: dropping Node.js 20 support in favour of Node.js 22
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-18
 prNumber: '892'
 ---

--- a/src/content/i-shipped/localfirstauth-framework-hooks-in-the-jazz-starter-templates.mdx
+++ b/src/content/i-shipped/localfirstauth-framework-hooks-in-the-jazz-starter-templates.mdx
@@ -1,6 +1,6 @@
 ---
 summary: LocalFirstAuth framework hooks in the Jazz starter templates
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-18
 prNumber: '894'
 ---

--- a/src/content/i-shipped/markdown-serving-for-ai-agents-from-the-jazz-docs.mdx
+++ b/src/content/i-shipped/markdown-serving-for-ai-agents-from-the-jazz-docs.mdx
@@ -1,6 +1,6 @@
 ---
 summary: markdown serving for AI agents from the Jazz docs
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-13
 prNumber: '856'
 ---

--- a/src/content/i-shipped/reactive-localfirstauth-support-for-svelte-and-vue.mdx
+++ b/src/content/i-shipped/reactive-localfirstauth-support-for-svelte-and-vue.mdx
@@ -1,6 +1,6 @@
 ---
 summary: reactive LocalFirstAuth support for Svelte and Vue
-repo: garden-co/classic-jazz
+repo: garden-co/jazz
 mergeDate: 2026-05-18
 prNumber: '879'
 ---


### PR DESCRIPTION
## Summary
Follow-up to PR #28. The bulk jazz→classic-jazz rename was too aggressive — it swept up 23 entries that were already written with the post-rename `garden-co/jazz` name (i.e. PRs that live in the new jazz repo, formerly jazz2).

Each of the 23 was validated against the GitHub API by author: classic-jazz/N returned a PR by a different author, jazz/N returned the joeinnes-authored PR. All 23 now correctly point to `garden-co/jazz`.

Also drops two entries with permanently unrecoverable links:
- `claude-improvements.mdx` — `spicygolf/spicy` is private/inaccessible (returns 404 even authenticated)
- `create-traistcoukmd.mdx` — `bradleytaunt/1mb-club`'s history was wiped during a platform migration; the file remains but PR #839 is gone

## Validation
All 241 `garden-co/jazz` and `garden-co/classic-jazz` entries on the resulting tree resolve to joeinnes-authored PRs (verified via `gh api repos/<repo>/pulls/<n> --jq .user.login`).

## Test plan
- [ ] Spot-check a handful of links on the /i-shipped page
- [ ] Vercel preview builds clean