### PR TITLE
Add standard.site ATProto integration + blog title animation

### DIFF
--- a/.github/workflows/standard-site.yml
+++ b/.github/workflows/standard-site.yml
@@ -1,0 +1,50 @@
+name: Publish to standard.site
+
+# Publishes / updates site.standard.document records when blog posts change on
+# main. The app password lives in the ATPROTO_APP_PASSWORD repo secret; the run
+# commits the updated manifest back so the next site build can emit the matching
+# verification <link> tags.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/content/posts/**"
+      - "scripts/standard-site/**"
+      - "standard-site.config.json"
+
+concurrency:
+  group: standard-site
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Sync posts to standard.site
+        env:
+          ATPROTO_APP_PASSWORD: ${{ secrets.ATPROTO_APP_PASSWORD }}
+        run: pnpm run standard-site:sync
+      - name: Commit manifest changes
+        run: |
+          if ! git diff --quiet standard-site.manifest.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add standard-site.manifest.json
+            git commit -m "chore: sync standard.site manifest [skip ci]"
+            git push
+          else
+            echo "Manifest unchanged."
+          fi

--- a/docs/standard-site-integration.md
+++ b/docs/standard-site-integration.md
@@ -1,0 +1,341 @@
+# standard.site ATProto integration — design
+
+Status: draft for review. Nothing here is built yet.
+
+## Goal
+
+Federate joeinn.es into the AT Protocol "Atmosphere" using the
+[standard.site](https://standard.site) lexicons, so that:
+
+1. Blog posts are published as `site.standard.document` records and become
+   discoverable/indexable by readers such as docs.surf, Pckt and Leaflet,
+   without a central gatekeeper.
+2. Replies to a Bluesky announcement post render as a federated comment thread
+   under each blog post.
+3. Posts you author elsewhere on the network (Leaflet, WhiteWind) can be pulled
+   back into the site.
+
+We start with the `posts` collection only, but the publishing layer is built as
+a registry of "publishable sources" so `smidgeons` and `iShipped` can be added
+later by registering one adapter each (see [Extensibility](#extensibility)).
+
+## Decisions locked in
+
+| Decision | Choice |
+|----------|--------|
+| Capabilities | Publish + federated comments + pull-in loader |
+| Implementation | [`@bryanguffey/astro-standard-site`](https://www.npmjs.com/package/@bryanguffey/astro-standard-site) (v1.0.4) |
+| Publish trigger | GitHub Action on merge to `main` |
+| Collections (phase 1) | Blog `posts` only, extensible to smidgeons + i-shipped |
+| MDX components | Replace unrenderable blocks with a "view on my blog" notice + canonical link |
+| Announcements | None automated — you post to Bluesky manually |
+| First run | Backfill all existing posts |
+| Comments | Opt-in per post via a `bskyPostUri` frontmatter field |
+
+## Your identity (already on the network)
+
+You already read ATProto directly in `NowPlaying.svelte`, so this slots into
+existing patterns.
+
+- Handle: `joeinn.es`
+- DID: `did:plc:me4kozmcrc74z2wgkvqvkbfd`
+- PDS entryway: `https://bsky.social`
+
+The publisher authenticates with a Bluesky [app password](https://bsky.app/settings/app-passwords)
+(never your main password).
+
+## How standard.site works (the bits that constrain the design)
+
+Two record types live in your PDS:
+
+- `site.standard.publication` — one record describing the blog (name, url,
+  description, optional theme colours). Created once.
+- `site.standard.document` — one record per post (title, `path`, `publishedAt`,
+  `description`, `content` as an open union, `textContent` for search indexing,
+  `tags`).
+
+Documents do not store their own canonical URL — a reader resolves it by joining
+the document `path` to the `url` on the referenced publication record.
+
+Verification is a two-way handshake an indexer checks:
+
+1. Your site serves `/.well-known/site.standard.publication` returning the
+   AT-URI of your publication record. (site → record)
+2. Each post's HTML carries a `<link>` tag pointing back to that post's
+   `site.standard.document` AT-URI. (record → post)
+
+There is a deliberate race condition: you create the record first (to obtain the
+AT-URI), then deploy the site with the matching `<link>` tag. Indexers expect a
+gap and re-verify on a schedule, so we do not need to solve it synchronously —
+but our publish-then-deploy ordering must respect it.
+
+### Longform vs microblog — answering the smidgeons question
+
+standard.site is explicitly longform-only. The microblog primitive on ATProto is
+`app.bsky.feed.post`; the two interlock — a Bluesky post that links a
+`site.standard.document` gets an enhanced preview in the Bluesky app. So:
+
+- `posts` → `site.standard.document` (longform). Phase 1.
+- `smidgeons` → `app.bsky.feed.post` (a real Bluesky post). There is no
+  "microblog via standard.site" prior art because that is not what the schema is
+  for. Smidgeons should become Bluesky posts and cross-link, not documents.
+- `iShipped` → either a small `site.standard.document` or a Bluesky post. Lowest
+  priority; decide when we get there.
+
+This also unifies with comments: the announcement Bluesky post we create for each
+longform document is itself the `app.bsky.feed.post`, and its replies are the
+comment thread.
+
+## Architecture
+
+```
+Keystatic edit / PR ──merge──▶ main
+                                 │
+                                 ▼
+              .github/workflows/standard-site.yml
+                                 │
+            ┌────────────────────┴─────────────────────┐
+            │  scripts/standard-site/sync.ts            │
+            │  1. read src/content/posts/*.mdx          │
+            │  2. diff each post vs manifest (hash)     │
+            │  3. new/changed → publishDocument()       │
+            │     (backfills everything on first run)   │
+            │  4. write standard-site.manifest.json     │
+            │     (slug → {docUri, docCid, hash})       │
+            └────────────────────┬─────────────────────┘
+                                 │ commits manifest back
+                                 ▼
+                         records live in PDS
+                                 │
+        Vercel build reads manifest ──▶ injects per-post:
+            • <link> tag → docUri              (verification)
+            • <Comments/> when frontmatter     (opt-in replies)
+              bskyPostUri is set
+                                 │
+                                 ▼
+          /.well-known/site.standard.publication  (verification)
+
+You share posts to Bluesky manually; doing so produces the enhanced preview on its
+own, because the page already carries the <link> tag. There is no automated posting.
+```
+
+Publishing (writes to your PDS) happens in CI. Verification surface (`.well-known`
++ `<link>` tags + comments) is plain build-time output driven by the committed
+manifest, so the site stays a normal Astro build with no secrets at build time.
+
+## Component 1 — publication record + `.well-known`
+
+One-time setup script (`scripts/standard-site/create-publication.ts`) calls
+`publishPublication({ name, url, description, basicTheme })` and prints the AT-URI.
+We record the publication rkey (the last path segment) in repo config.
+
+The well-known endpoint is an Astro route so the content-type is correct:
+
+```ts
+// src/pages/.well-known/site.standard.publication.ts
+import type { APIRoute } from "astro";
+import { generatePublicationWellKnown } from "@bryanguffey/astro-standard-site";
+
+export const GET: APIRoute = () =>
+  new Response(
+    generatePublicationWellKnown({
+      did: "did:plc:me4kozmcrc74z2wgkvqvkbfd",
+      publicationRkey: "<rkey-from-create-publication>",
+    }),
+    { headers: { "Content-Type": "text/plain" } },
+  );
+```
+
+(Works with the Vercel adapter. A static `public/.well-known/...` file is the
+alternative but risks the wrong content-type.)
+
+## Component 2 — publishing pipeline (GitHub Action)
+
+`scripts/standard-site/sync.ts` is the heart of it. Design points:
+
+- Reads post sources directly with `gray-matter` (no full Astro build needed in
+  CI). Slug = filename; `path` = `/blog/<slug>`; `site` = `https://joeinn.es`.
+- Transforms the MDX body via the package's `transformContent(body, { baseUrl })`
+  to produce `content.text` (markdown) and `textContent` (plain text + word count
+  / reading time). See the [MDX caveat](#mdx-caveat).
+- Idempotency via a committed manifest, `standard-site.manifest.json`:
+
+  ```jsonc
+  {
+    "version": 1,
+    "documents": {
+      "my-post-slug": {
+        "docUri": "at://did:plc:.../site.standard.document/3l...",
+        "docCid": "bafy...",
+        "contentHash": "sha256:..."
+      }
+    }
+  }
+  ```
+
+  - Slug absent from manifest → `publishDocument()` (create) → add entry. On the
+    first run this backfills every existing post.
+  - `contentHash` changed → update the existing record (see gap below).
+  - Unchanged → skip.
+
+- Ordering respects the race condition: the Action publishes records and commits
+  the manifest first; the subsequent Vercel deploy then ships the `<link>` tags.
+- Secrets: `ATPROTO_APP_PASSWORD` as a GitHub Actions secret; DID and publication
+  rkey as repo-level config (non-secret).
+
+Update semantics (confirmed): the publisher exposes `updateDocument(rkey, input)`
+(via `putRecord`) and `deleteDocument(rkey)` (via `deleteRecord`), plus
+`listDocuments()`. So changed posts update in place using the stored rkey, and
+unpublishing is a delete — no recreate-on-change workaround needed.
+
+## Component 3 — federated comments (opt-in, manual)
+
+No automated posting. When you want comments on a post, you share it on Bluesky
+yourself, copy that post's AT-URI, and paste it into the post's frontmatter. The
+component renders only when the field is present, so comments are opt-in per post
+and the publishing pipeline is not involved at all.
+
+Add the field to the `posts` schema:
+
+```ts
+// src/content/config.ts — posts schema
+bskyPostUri: z.string().optional(),
+```
+
+Then in `src/pages/blog/[slug].astro`:
+
+```astro
+---
+import Comments from "@bryanguffey/astro-standard-site/components/Comments.astro";
+---
+{post.data.bskyPostUri && (
+  <Comments bskyPostUri={post.data.bskyPostUri} canonicalUrl={Astro.url.href} maxDepth={3} />
+)}
+```
+
+No auth, no client secrets — it reads public replies. The manifest is not
+involved. Styling hooks into existing CSS custom properties (the component exposes
+`--color-*` / `--space-*` variables we can map to `styles.css`).
+
+Because the page already carries the standard.site `<link>` tag, manually sharing
+the canonical URL on Bluesky gives you the enhanced preview too — so one manual
+post yields both the rich preview and the comment thread, with no automation.
+
+## Component 4 — pull-in loader (posts written elsewhere)
+
+A new content collection backed by the package's content-layer loader, excluding
+anything originating from this site so we never double-list our own posts:
+
+```ts
+// src/content/config.ts
+import { standardSiteLoader } from "@bryanguffey/astro-standard-site";
+
+const federated = defineCollection({
+  loader: standardSiteLoader({
+    repo: "joeinn.es",
+    excludeSite: "https://joeinn.es",
+  }),
+});
+export const collections = { posts, smidgeons, iShipped, federated };
+```
+
+Rendered on a small page (e.g. `/elsewhere` or folded into `/blog`) linking out to
+the canonical platform. Phase 3 — lowest priority.
+
+## Extensibility
+
+The sync engine iterates a registry of adapters rather than hard-coding `posts`:
+
+```ts
+interface PublishableSource {
+  collection: string;                       // "posts" | "smidgeons" | "iShipped"
+  target: "site.standard.document" | "app.bsky.feed.post";
+  glob: string;                             // e.g. "src/content/posts/*.mdx"
+  shouldPublish(entry): boolean;            // skip drafts etc.
+  pathFor(entry): string;                   // canonical path on the site
+  toRecord(entry): Record<string, unknown>; // map frontmatter+body → lexicon
+}
+```
+
+Phase 1 registers only the `posts` adapter (→ document). Adding smidgeons later is
+"register one adapter targeting `app.bsky.feed.post`"; i-shipped likewise. The
+manifest keys by `collection:slug` so the three never collide.
+
+## File-by-file change list
+
+New:
+- `scripts/standard-site/create-publication.mjs` — one-time publication record (done)
+- `scripts/standard-site/sync.mjs` — the sync engine + `posts` adapter
+- `scripts/standard-site/sources.mjs` — the `PublishableSource` registry
+- `src/pages/.well-known/site.standard.publication.ts` — verification endpoint
+- `.github/workflows/standard-site.yml` — runs sync on merge to `main`
+- `standard-site.manifest.json` — committed slug → record map
+
+Modified:
+- `src/pages/blog/[slug].astro` — add the `<link>` verification tag + opt-in `<Comments/>`
+- `src/content/config.ts` — add `bskyPostUri` to the posts schema (comments); add
+  the `federated` collection (phase 3)
+- `package.json` — add `@bryanguffey/astro-standard-site` (deps), `gray-matter`,
+  `tsx` (devDeps); add an npm script for the manual sync
+
+Config / secrets:
+- GitHub secret `ATPROTO_APP_PASSWORD`
+- Non-secret config: DID + publication rkey (a small `standard-site.config.json`
+  or env in the workflow)
+
+## Risks and gotchas
+
+<a id="mdx-caveat"></a>
+- MDX content (decided). Posts are MDX and can import Svelte/React widgets, which
+  external readers cannot render. The posts adapter pre-processes the body before
+  `transformContent`: ESM `import`/`export` lines are stripped, and each JSX
+  component block is replaced with a short notice linking to the canonical post,
+  e.g. `> This post includes an interactive component — [view it on joeinn.es](<canonical-url>)`.
+  Prose-only posts pass through unchanged, and the notice text flows into
+  `textContent` too. The detection heuristic (JSX element + import-line matching)
+  is firmed up during the spike.
+- `<link>` tag exact shape (confirmed). The package's `generateDocumentLinkTag({ did, documentRkey })`
+  emits `<link rel="site.standard.document" href="at://<did>/site.standard.document/<rkey>">`.
+  That is the tag we inject into `[slug].astro`.
+- Update semantics (confirmed). `updateDocument`/`deleteDocument` exist — see
+  Component 2.
+- Deletions / unpublishing. Removing a post should `deleteRecord` and prune the
+  manifest. Phase 1 can defer this, but the manifest makes it tractable.
+- Slug/path stability. The canonical `path` is the verification anchor; renaming a
+  post slug changes its URL and breaks verification until re-published. Treat slug
+  as stable once published.
+- CI write-back loop. The Action commits the manifest back to `main`; guard the
+  workflow against retriggering itself (path filter / `[skip ci]` / bot-author
+  check).
+
+## Suggested rollout
+
+1. Setup (done / pending your run): the package is installed and
+   `scripts/standard-site/create-publication.mjs` is written. Run it once with your
+   app password to create the publication record and obtain its rkey. The earlier
+   unknowns (`<link>` shape, update semantics) are already settled from the package
+   source, so no investigative spike is needed.
+2. Phase 1: manifest + `posts` adapter (incl. MDX component-notice rule) + backfill
+   + `<link>` tag + well-known + the Action.
+3. Phase 2: opt-in `<Comments/>` via the `bskyPostUri` frontmatter field.
+4. Phase 3: pull-in loader; then optionally smidgeons (→ `app.bsky.feed.post`).
+
+## Decisions resolved
+
+These were the open questions; all now settled and folded into the design above.
+
+1. MDX: replace unrenderable component blocks with a "view on my blog" notice +
+   canonical link; prose-only posts pass through. (See the MDX item under Risks.)
+2. Announcements: none automated — you post to Bluesky manually. The Action only
+   publishes `site.standard.document` records.
+3. First run: backfill all existing posts.
+4. Comments: opt-in per post via a `bskyPostUri` frontmatter field.
+
+## Sources
+
+- [Indexing Standard Site — atproto.com](https://atproto.com/blog/indexing-standard-site)
+- [standard.site](https://standard.site)
+- [@bryanguffey/astro-standard-site — npm](https://www.npmjs.com/package/@bryanguffey/astro-standard-site)
+- [astro-standard-site — GitHub](https://github.com/musicjunkieg/astro-standard-site)
+- [Standard.site: the Publishing Gateway — Steve Simkins](https://stevedylan.dev/posts/standard-site-the-publishing-gateway/)
+- [Integrating Standard Site into Bluesky — discussion #4978](https://github.com/bluesky-social/atproto/discussions/4978)

--- a/keystatic.config.tsx
+++ b/keystatic.config.tsx
@@ -25,7 +25,7 @@ export default config({
           label: "Date",
         }),
         date_updated: fields.date({
-          label: "Date",
+          label: "Date Updated",
           validation: {
             isRequired: false,
           },
@@ -41,6 +41,12 @@ export default config({
           label: "Featured Image",
           directory: "./public",
           publicPath: "",
+        }),
+        bskyPostUri: fields.text({
+          label: "Bluesky Post URI (comments)",
+          description:
+            "Optional. To show comments, share this post on Bluesky, copy the post's AT-URI (at://…) and paste it here. Leave blank for no comments.",
+          validation: { isRequired: false },
         }),
         content: fields.mdx({
           label: "Content",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/react": "4.3.0",
     "@astrojs/svelte": "^7.1.0",
     "@astrojs/vercel": "^8.2.6",
+    "@bryanguffey/astro-standard-site": "^1.0.3",
     "@keystatic/astro": "^5.0.6",
     "@keystatic/core": "^0.5.47",
     "@tailwindcss/vite": "^4.1.10",
@@ -34,9 +35,12 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "standard-site:publication": "node scripts/standard-site/create-publication.mjs",
+    "standard-site:sync": "node scripts/standard-site/sync.mjs"
   },
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.16"
+    "@tailwindcss/typography": "^0.5.16",
+    "gray-matter": "^4.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@astrojs/vercel':
         specifier: ^8.2.6
         version: 8.2.6(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)(rollup@4.44.0)(svelte@5.34.7)
+      '@bryanguffey/astro-standard-site':
+        specifier: ^1.0.3
+        version: 1.0.3(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))
       '@keystatic/astro':
         specifier: ^5.0.6
         version: 5.0.6(@keystatic/core@0.5.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -72,6 +75,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.10)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
 
 packages:
 
@@ -137,6 +143,33 @@ packages:
     resolution: {integrity: sha512-ctGEoAtyWvFtUNuVECwXwDHMv6lxw1m1qcUL6ZNACFL7GIDzHhD/ipAkZsl2G4QUeVD1ig0Xo8AtFdDl34/gNg==}
     peerDependencies:
       astro: ^5.0.0
+
+  '@atproto/api@0.15.27':
+    resolution: {integrity: sha512-ok/WGafh1nz4t8pEQGtAF/32x2E2VDWU4af6BajkO5Gky2jp2q6cv6aB2A5yuvNNcc3XkYMYipsqVHVwLPMF9g==}
+
+  '@atproto/common-web@0.4.21':
+    resolution: {integrity: sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==}
+
+  '@atproto/lex-data@0.0.15':
+    resolution: {integrity: sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==}
+
+  '@atproto/lex-json@0.0.16':
+    resolution: {integrity: sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==}
+
+  '@atproto/lexicon@0.4.14':
+    resolution: {integrity: sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==}
+
+  '@atproto/lexicon@0.6.2':
+    resolution: {integrity: sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==}
+
+  '@atproto/syntax@0.4.3':
+    resolution: {integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==}
+
+  '@atproto/syntax@0.5.4':
+    resolution: {integrity: sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==}
+
+  '@atproto/xrpc@0.7.7':
+    resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -223,6 +256,11 @@ packages:
 
   '@braintree/sanitize-url@6.0.4':
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
+
+  '@bryanguffey/astro-standard-site@1.0.3':
+    resolution: {integrity: sha512-+4//yk8rRD3ZfC9uOKY7OHu7Shm5qMZSgFTIcDs079hcoV42yF8mK8O0AI6QMFb7iMCPqN9rO+leP+PMEEmR3A==}
+    peerDependencies:
+      astro: ^5.0.0
 
   '@capsizecss/unpack@2.4.0':
     resolution: {integrity: sha512-GrSU71meACqcmIUxPYOJvGKF0yryjN/L1aCuE9DViCTJI7bfkjgYDPD1zbNDcINJwSSP6UaBZY9GAbYDO7re0Q==}
@@ -502,138 +540,163 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.1.0':
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1351,56 +1414,67 @@ packages:
     resolution: {integrity: sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.44.0':
     resolution: {integrity: sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.44.0':
     resolution: {integrity: sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.44.0':
     resolution: {integrity: sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.44.0':
     resolution: {integrity: sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.44.0':
     resolution: {integrity: sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.44.0':
     resolution: {integrity: sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.44.0':
     resolution: {integrity: sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.44.0':
     resolution: {integrity: sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.44.0':
     resolution: {integrity: sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.44.0':
     resolution: {integrity: sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.44.0':
     resolution: {integrity: sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==}
@@ -1507,24 +1581,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.10':
     resolution: {integrity: sha512-saScU0cmWvg/Ez4gUmQWr9pvY9Kssxt+Xenfx1LG7LmqjcrvBnw4r9VjkFcqmbBb7GCBwYNcZi9X3/oMda9sqQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.10':
     resolution: {integrity: sha512-/G3ao/ybV9YEEgAXeEg28dyH6gs1QG8tvdN9c2MNZdUXYBaIY/Gx0N6RlJzfLy/7Nkdok4kaxKPHKJUlAaoTdA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.10':
     resolution: {integrity: sha512-LNr7X8fTiKGRtQGOerSayc2pWJp/9ptRYAa4G+U+cjw9kJZvkopav1AQc5HHD+U364f71tZv6XamaHKgrIoVzA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.10':
     resolution: {integrity: sha512-d6ekQpopFQJAcIK2i7ZzWOYGZ+A6NzzvQ3ozBvWFdeyqfOZdYHU66g5yr+/HC4ipP1ZgWsqa80+ISNILk+ae/Q==}
@@ -1771,6 +1849,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1796,6 +1877,9 @@ packages:
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2114,6 +2198,11 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esrap@1.4.9:
     resolution: {integrity: sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==}
 
@@ -2147,6 +2236,10 @@ packages:
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2227,6 +2320,10 @@ packages:
   graphql@16.11.0:
     resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   h3@1.15.3:
     resolution: {integrity: sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==}
@@ -2344,6 +2441,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -2380,6 +2481,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  iso-datestring-validator@2.2.2:
+    resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
+
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
@@ -2392,6 +2496,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -2412,6 +2520,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -2455,24 +2567,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2726,6 +2842,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multiformats@9.9.0:
+    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3042,6 +3161,10 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3117,6 +3240,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3139,6 +3265,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -3203,6 +3333,10 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -3237,6 +3371,9 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  uint8arrays@3.0.0:
+    resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -3248,6 +3385,9 @@ packages:
 
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
+  unicode-segmenter@0.14.5:
+    resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
@@ -3704,6 +3844,65 @@ snapshots:
       - vue
       - vue-router
 
+  '@atproto/api@0.15.27':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/lexicon': 0.4.14
+      '@atproto/syntax': 0.4.3
+      '@atproto/xrpc': 0.7.7
+      await-lock: 2.2.2
+      multiformats: 9.9.0
+      tlds: 1.261.0
+      zod: 3.25.67
+
+  '@atproto/common-web@0.4.21':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      '@atproto/lex-json': 0.0.16
+      '@atproto/syntax': 0.5.4
+      zod: 3.25.67
+
+  '@atproto/lex-data@0.0.15':
+    dependencies:
+      multiformats: 9.9.0
+      tslib: 2.8.1
+      uint8arrays: 3.0.0
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.0.16':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.4.14':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.4.3
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.25.67
+
+  '@atproto/lexicon@0.6.2':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.5.4
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.25.67
+
+  '@atproto/syntax@0.4.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/syntax@0.5.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.7.7':
+    dependencies:
+      '@atproto/lexicon': 0.6.2
+      zod: 3.25.67
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -3817,6 +4016,12 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@braintree/sanitize-url@6.0.4': {}
+
+  '@bryanguffey/astro-standard-site@1.0.3(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))':
+    dependencies:
+      '@atproto/api': 0.15.27
+      astro: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+      zod: 3.25.67
 
   '@capsizecss/unpack@2.4.0':
     dependencies:
@@ -5831,6 +6036,10 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -5945,6 +6154,8 @@ snapshots:
       - yaml
 
   async-sema@3.1.1: {}
+
+  await-lock@2.2.2: {}
 
   axobject-query@4.1.0: {}
 
@@ -6240,6 +6451,8 @@ snapshots:
 
   esm-env@1.2.2: {}
 
+  esprima@4.0.1: {}
+
   esrap@1.4.9:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -6282,6 +6495,10 @@ snapshots:
   event-target-shim@6.0.2: {}
 
   eventemitter3@5.0.1: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   extend@3.0.2: {}
 
@@ -6354,6 +6571,13 @@ snapshots:
       tslib: 2.8.1
 
   graphql@16.11.0: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   h3@1.15.3:
     dependencies:
@@ -6569,6 +6793,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extendable@0.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-hexadecimal@2.0.1: {}
@@ -6595,6 +6821,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  iso-datestring-validator@2.2.2: {}
+
   isomorphic.js@0.2.5: {}
 
   jackspeak@3.4.3:
@@ -6606,6 +6834,11 @@ snapshots:
   jiti@2.4.2: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.0:
     dependencies:
@@ -6619,6 +6852,8 @@ snapshots:
     optional: true
 
   json5@2.2.3: {}
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -7171,6 +7406,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multiformats@9.9.0: {}
+
   nanoid@3.3.11: {}
 
   nanoid@5.1.5: {}
@@ -7585,6 +7822,11 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -7707,6 +7949,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sprintf-js@1.0.3: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -7737,6 +7981,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-bom-string@1.0.0: {}
 
   style-to-js@1.1.17:
     dependencies:
@@ -7810,6 +8056,8 @@ snapshots:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tlds@1.261.0: {}
+
   tr46@0.0.3: {}
 
   trim-lines@3.0.1: {}
@@ -7828,6 +8076,10 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  uint8arrays@3.0.0:
+    dependencies:
+      multiformats: 9.9.0
+
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
@@ -7838,6 +8090,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       unicode-trie: 2.0.0
+
+  unicode-segmenter@0.14.5: {}
 
   unicode-trie@2.0.0:
     dependencies:

--- a/scripts/standard-site/create-publication.mjs
+++ b/scripts/standard-site/create-publication.mjs
@@ -1,0 +1,52 @@
+// One-time setup: create (or reuse) the site.standard.publication record for the
+// blog, and print its rkey. Idempotent — re-running will not create duplicates.
+//
+// Run locally with a Bluesky app password (Settings → Privacy and security →
+// App passwords). The password never leaves your machine:
+//
+//   ATPROTO_APP_PASSWORD='xxxx-xxxx-xxxx-xxxx' node scripts/standard-site/create-publication.mjs
+//
+// Copy the printed rkey into src/pages/.well-known/site.standard.publication.ts.
+
+import { StandardSitePublisher } from "@bryanguffey/astro-standard-site/publisher";
+
+const HANDLE = "joeinn.es";
+const SITE_URL = "https://joeinn.es";
+
+const password = process.env.ATPROTO_APP_PASSWORD;
+if (!password) {
+  console.error(
+    "Missing ATPROTO_APP_PASSWORD. Create an app password at\n" +
+      "https://bsky.app/settings/app-passwords and run:\n\n" +
+      "  ATPROTO_APP_PASSWORD='xxxx-xxxx-xxxx-xxxx' node scripts/standard-site/create-publication.mjs",
+  );
+  process.exit(1);
+}
+
+const publisher = new StandardSitePublisher({ identifier: HANDLE, password });
+
+await publisher.login();
+console.log(`Logged in as ${publisher.getDid()} via ${publisher.getPdsUrl()}`);
+
+// Reuse an existing publication for this site if one is already present.
+const existing = await publisher.listPublications();
+const match = existing.find((p) => p.value?.url === SITE_URL);
+if (match) {
+  console.log("\nPublication already exists — nothing to do.");
+  console.log(`AT-URI : ${match.uri}`);
+  console.log(`rkey   : ${match.uri.split("/").pop()}`);
+  process.exit(0);
+}
+
+const result = await publisher.publishPublication({
+  name: "Joe Innes",
+  url: SITE_URL,
+  description: "Personal website and blog of Joe Innes.",
+});
+
+console.log("\nPublication created.");
+console.log(`AT-URI : ${result.uri}`);
+console.log(`rkey   : ${result.uri.split("/").pop()}`);
+console.log(
+  "\nNext: paste that rkey into src/pages/.well-known/site.standard.publication.ts",
+);

--- a/scripts/standard-site/sources.mjs
+++ b/scripts/standard-site/sources.mjs
@@ -1,0 +1,91 @@
+// Registry of "publishable sources". Each source maps a content collection to a
+// standard.site / ATProto record. Phase 1 registers blog posts only; adding
+// smidgeons or i-shipped later is a matter of appending one source to SOURCES
+// (smidgeons would target app.bsky.feed.post — standard.site is longform-only).
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+
+const NOTICE = "This post includes an interactive component.";
+
+// External longform readers can't render MDX components, so replace the bits they
+// can't handle with a short notice linking back to the canonical post.
+function stripMdxComponents(body, canonicalUrl) {
+  const notice = `> ${NOTICE} [View it on joeinn.es](${canonicalUrl})`;
+  let out = body
+    // Drop ESM import/export lines (component wiring).
+    .replace(/^[ \t]*(?:import|export)\b.*$/gm, "")
+    // Paired component blocks: <Tag ...> ... </Tag> (component = uppercase initial).
+    .replace(/<([A-Z][\w.]*)\b[^>]*>[\s\S]*?<\/\1>/g, notice)
+    // Self-closing components: <Tag ... />.
+    .replace(/<[A-Z][\w.]*\b[^>]*\/>/g, notice);
+
+  // Collapse runs of consecutive notice lines into one.
+  out = out
+    .split("\n")
+    .filter((line, i, arr) => !(line.includes(NOTICE) && (arr[i - 1] ?? "").includes(NOTICE)))
+    .join("\n");
+
+  return out.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export const postsSource = {
+  collection: "posts",
+  target: "site.standard.document",
+  dir: "src/content/posts",
+
+  list() {
+    return readdirSync(this.dir)
+      .filter((f) => /\.mdx?$/.test(f))
+      .map((file) => {
+        const slug = file.replace(/\.mdx?$/, "");
+        const { data, content } = matter(readFileSync(join(this.dir, file), "utf8"));
+        return { slug, file, data, body: content };
+      });
+  },
+
+  shouldPublish(entry) {
+    if (entry.data.draft) return false;
+    const date = new Date(entry.data.date);
+    return !Number.isNaN(date.getTime()) && date <= new Date();
+  },
+
+  pathFor(entry) {
+    return `/blog/${entry.slug}`;
+  },
+
+  // Build the publishDocument input (minus `site`, which the engine adds).
+  // `transform` is the package's transformContent helper.
+  toInput(entry, { siteUrl, transform }) {
+    const path = this.pathFor(entry);
+    const canonicalUrl = siteUrl + path;
+    const cleaned = stripMdxComponents(entry.body, canonicalUrl);
+    const { markdown, textContent } = transform(cleaned, { siteUrl, postPath: path });
+
+    return {
+      title: entry.data.title,
+      path,
+      publishedAt: new Date(entry.data.date).toISOString(),
+      ...(entry.data.date_updated
+        ? { updatedAt: new Date(entry.data.date_updated).toISOString() }
+        : {}),
+      ...(entry.data.excerpt ? { description: entry.data.excerpt } : {}),
+      textContent,
+      content: { $type: "site.standard.content.markdown", text: markdown, version: "1.0" },
+    };
+  },
+
+  // Fields that, when changed, should trigger a re-publish.
+  hashInput(entry) {
+    return JSON.stringify({
+      title: entry.data.title,
+      date: entry.data.date,
+      date_updated: entry.data.date_updated ?? null,
+      excerpt: entry.data.excerpt ?? null,
+      body: entry.body,
+    });
+  },
+};
+
+export const SOURCES = [postsSource];

--- a/scripts/standard-site/sync.mjs
+++ b/scripts/standard-site/sync.mjs
@@ -1,0 +1,101 @@
+// Sync engine: diff each publishable source against the manifest and create,
+// update or delete standard.site documents accordingly. Idempotent — only
+// changed posts are touched.
+//
+//   node scripts/standard-site/sync.mjs            # publish (needs app password)
+//   node scripts/standard-site/sync.mjs --dry-run  # report the plan only
+//
+// Auth: set ATPROTO_APP_PASSWORD (a Bluesky app password). With no password set,
+// it falls back to a dry run so it is always safe to run.
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { StandardSitePublisher } from "@bryanguffey/astro-standard-site/publisher";
+import { transformContent } from "@bryanguffey/astro-standard-site/content";
+import { SOURCES } from "./sources.mjs";
+
+const CONFIG_PATH = "standard-site.config.json";
+const MANIFEST_PATH = "standard-site.manifest.json";
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+manifest.documents ??= {};
+
+const password = process.env.ATPROTO_APP_PASSWORD;
+const dryRun = process.argv.includes("--dry-run") || !password;
+
+const sha256 = (s) => "sha256:" + createHash("sha256").update(s).digest("hex");
+const rkeyOf = (uri) => uri.split("/").pop();
+
+// Desired state across all sources.
+const desired = new Map(); // key -> { source, entry }
+for (const source of SOURCES) {
+  for (const entry of source.list()) {
+    if (source.shouldPublish(entry)) desired.set(`${source.collection}:${entry.slug}`, { source, entry });
+  }
+}
+
+const actions = { create: [], update: [], delete: [], skip: 0 };
+
+for (const [key, { source, entry }] of desired) {
+  const hash = sha256(source.hashInput(entry));
+  const existing = manifest.documents[key];
+  if (!existing) actions.create.push({ key, source, entry, hash });
+  else if (existing.contentHash !== hash)
+    actions.update.push({ key, source, entry, hash, rkey: rkeyOf(existing.docUri) });
+  else actions.skip += 1;
+}
+
+// Deletes: managed entries that are no longer desired (post removed / unpublished).
+const managed = new Set(SOURCES.map((s) => s.collection));
+for (const [key, record] of Object.entries(manifest.documents)) {
+  if (managed.has(key.split(":")[0]) && !desired.has(key)) {
+    actions.delete.push({ key, rkey: rkeyOf(record.docUri) });
+  }
+}
+
+console.log(
+  `Plan: ${actions.create.length} create, ${actions.update.length} update, ` +
+    `${actions.delete.length} delete, ${actions.skip} unchanged` +
+    (dryRun ? "   (dry run)" : ""),
+);
+for (const a of actions.create) console.log(`  + ${a.key}`);
+for (const a of actions.update) console.log(`  ~ ${a.key}`);
+for (const a of actions.delete) console.log(`  - ${a.key}`);
+
+if (dryRun) {
+  if (!password) console.log("\nNo ATPROTO_APP_PASSWORD set — dry run only, nothing published.");
+  process.exit(0);
+}
+
+if (!actions.create.length && !actions.update.length && !actions.delete.length) {
+  console.log("Nothing to do.");
+  process.exit(0);
+}
+
+const publisher = new StandardSitePublisher({ identifier: config.handle, password });
+await publisher.login();
+console.log(`Logged in as ${publisher.getDid()} via ${publisher.getPdsUrl()}`);
+
+const ctx = { siteUrl: config.siteUrl, transform: transformContent };
+
+for (const a of actions.create) {
+  const input = { site: config.siteUrl, ...a.source.toInput(a.entry, ctx) };
+  const res = await publisher.publishDocument(input);
+  manifest.documents[a.key] = { docUri: res.uri, docCid: res.cid, contentHash: a.hash };
+  console.log(`created ${a.key} → ${res.uri}`);
+}
+for (const a of actions.update) {
+  const input = { site: config.siteUrl, ...a.source.toInput(a.entry, ctx) };
+  const res = await publisher.updateDocument(a.rkey, input);
+  manifest.documents[a.key] = { docUri: res.uri, docCid: res.cid, contentHash: a.hash };
+  console.log(`updated ${a.key} → ${res.uri}`);
+}
+for (const a of actions.delete) {
+  await publisher.deleteDocument(a.rkey);
+  delete manifest.documents[a.key];
+  console.log(`deleted ${a.key}`);
+}
+
+writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n");
+console.log(`\nWrote ${MANIFEST_PATH}.`);

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,8 +7,12 @@ const posts = defineCollection({
     title: z.string(),
     page_bg: z.string().optional(),
     date: z.date(),
+    date_updated: z.date().optional(),
+    draft: z.boolean().optional(),
     excerpt: z.string().optional(),
     featured_image: z.string().optional(),
+    // AT-URI of a Bluesky post; when set, its replies render as comments.
+    bskyPostUri: z.string().optional(),
   }),
 });
 

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -30,6 +30,7 @@ const { title, bg } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <ClientRouter />
+    <slot name="head" />
   </head>
   <body>
     <slot />

--- a/src/pages/.well-known/site.standard.publication.ts
+++ b/src/pages/.well-known/site.standard.publication.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro";
+import { generatePublicationWellKnown } from "@bryanguffey/astro-standard-site";
+import config from "../../../standard-site.config.json";
+
+// Verification endpoint: returns the AT-URI of the site.standard.publication
+// record, proving this site owns it. Prerendered to a static file.
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+  new Response(
+    generatePublicationWellKnown({
+      did: config.did,
+      publicationRkey: config.publicationRkey,
+    }),
+    { headers: { "Content-Type": "text/plain" } },
+  );

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -3,6 +3,10 @@ import { getCollection, getEntry } from "astro:content";
 import Layout from "../../layouts/Default.astro";
 import Nav from "../../components/NewNav.astro";
 import Signature from "../../components/Signature.svelte";
+import Comments from "@bryanguffey/astro-standard-site/components/Comments.astro";
+import { generateDocumentLinkTag } from "@bryanguffey/astro-standard-site";
+import manifest from "../../../standard-site.manifest.json";
+import siteConfig from "../../../standard-site.config.json";
 
 const { slug } = Astro.params;
 if (!slug) throw new Error("Slug not found");
@@ -10,6 +14,15 @@ const post = await getEntry("posts", slug);
 
 if (!post) throw new Error("No post found for this slug");
 const { Content } = await post.render();
+
+// standard.site verification: if this post has been published, emit a <link>
+// pointing back to its document record.
+const docRecord = manifest.documents?.[`posts:${slug}`];
+const docRkey = docRecord?.docUri.split("/").pop();
+const linkTag = docRkey
+  ? generateDocumentLinkTag({ did: siteConfig.did, documentRkey: docRkey })
+  : null;
+const canonicalUrl = `${siteConfig.siteUrl}/blog/${post.slug}`;
 
 // Generate static pages
 export async function getStaticPaths() {
@@ -24,6 +37,7 @@ export async function getStaticPaths() {
   }
 </style>
 <Layout title={post.data.title} bg={post.data.page_bg}>
+  {linkTag && <Fragment slot="head" set:html={linkTag} />}
   <main>
     <Nav />
     <hgroup class="content meta">
@@ -64,5 +78,14 @@ export async function getStaticPaths() {
         <Signature client:load />
       </div>
     </article>
+    {
+      post.data.bskyPostUri && (
+        <Comments
+          bskyPostUri={post.data.bskyPostUri}
+          canonicalUrl={canonicalUrl}
+          maxDepth={3}
+        />
+      )
+    }
   </main>
 </Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -133,7 +133,16 @@ const dateSort = (a, b) => new Date(b.data.date) - new Date(a.data.date);
                     })}
                   </time>
                   <div>
-                    <h2 transition:name={`post-title-${post.slug}`}>{post?.data.title}</h2>
+                    <h2 transition:name={`post-title-${post.slug}`}>
+                      {post.data.title.split(/\s+/).map((word, i, arr) => (
+                        <Fragment>
+                          <span class="word" style={`--word-index: ${i}`}>
+                            {word}
+                          </span>
+                          {i < arr.length - 1 ? " " : ""}
+                        </Fragment>
+                      ))}
+                    </h2>
                   </div>
 
                   {post?.data.excerpt ||
@@ -182,17 +191,26 @@ const dateSort = (a, b) => new Date(b.data.date) - new Date(a.data.date);
 </Layout>
 
 <style lang="postcss">
-	article h2 {
+	article h2 .word {
+		display: inline-block;
 		text-decoration: none;
 		background-image: linear-gradient(var(--border-colour), var(--border-colour));
 		background-position: 0% 100%;
 		background-repeat: no-repeat;
 		background-size: 0% 0.3rem;
-		transition: background-size 0.3s;
+		transition: background-size 0.3s ease;
+		/* Stagger each word so the underline sweeps across one word at a time */
+		transition-delay: calc(var(--word-index, 0) * 0.07s);
 	}
 
-	article:hover h2,
-	article:focus h2 {
+	a:hover h2 .word,
+	a:focus-visible h2 .word {
 		background-size: 100% 0.3rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		article h2 .word {
+			transition-delay: 0s;
+		}
 	}
 </style>

--- a/standard-site.config.json
+++ b/standard-site.config.json
@@ -1,0 +1,7 @@
+{
+  "did": "did:plc:me4kozmcrc74z2wgkvqvkbfd",
+  "handle": "joeinn.es",
+  "siteUrl": "https://joeinn.es",
+  "publicationRkey": "3mn5e34og4kwl",
+  "publicationUri": "at://did:plc:me4kozmcrc74z2wgkvqvkbfd/site.standard.publication/3mn5e34og4kwl"
+}

--- a/standard-site.manifest.json
+++ b/standard-site.manifest.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "documents": {}
+}


### PR DESCRIPTION
## Summary
- Federate blog posts to the AT Protocol via the standard.site lexicons (`@bryanguffey/astro-standard-site`): a diff-based sync engine publishes `site.standard.document` records on merge to main, with a `.well-known/site.standard.publication` endpoint and per-post `<link rel="site.standard.document">` verification tags.
- MDX components are swapped for a notice linking to the canonical post (external longform readers cannot render them); drafts and future-dated posts are skipped.
- Opt-in federated comments via a `bskyPostUri` field, added to both the Astro content schema and the Keystatic CMS schema.
- Fix the blog listing `draft` filter — the Astro schema was ignoring `draft`, so 9 draft posts were showing; also relabel the Keystatic `date_updated` field.
- Animate blog post-title underlines word by word on hover (separate commit).

## Test plan
- [ ] `npm run build` completes; `/blog`, every `/blog/[slug]` page and `/.well-known/site.standard.publication` generate.
- [ ] `pnpm run standard-site:sync -- --dry-run` lists the publishable posts and applies the MDX notice rule.
- [ ] After the backfill, a published post's HTML carries `<link rel="site.standard.document" …>` and the well-known returns the publication AT-URI.
- [ ] Set a post's `bskyPostUri`, rebuild, and confirm Bluesky replies render as comments.