### PR TITLE
Fix inflated line spacing on wrapped blog titles

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -192,7 +192,8 @@ const dateSort = (a, b) => new Date(b.data.date) - new Date(a.data.date);
 
 <style lang="postcss">
 	article h2 .word {
-		display: inline-block;
+		/* Keep words inline (not inline-block) so wrapped title lines don't gain
+		   extra leading; the gradient underline animates fine on inline spans. */
 		text-decoration: none;
 		background-image: linear-gradient(var(--border-colour), var(--border-colour));
 		background-position: 0% 100%;


### PR DESCRIPTION
## Summary
- The per-word title underline used `display: inline-block`, which inflated the line-box height so wrapped titles (e.g. "Summer Berry Ripple Cake") gained extra leading between lines. Revert the word spans to inline; the gradient underline animation is unchanged.

## Test plan
- [ ] Open `/blog` and confirm a wrapping title has normal line spacing (heading `line-height` 1.2).
- [ ] Hover a title and confirm each word underlines left to right.