### PR TITLE
Harden standard.site sync for safe backfill

### DIFF
--- a/.github/workflows/standard-site.yml
+++ b/.github/workflows/standard-site.yml
@@ -12,6 +12,7 @@ on:
       - "src/content/posts/**"
       - "scripts/standard-site/**"
       - "standard-site.config.json"
+  workflow_dispatch:
 
 concurrency:
   group: standard-site
@@ -37,13 +38,18 @@ jobs:
         env:
           ATPROTO_APP_PASSWORD: ${{ secrets.ATPROTO_APP_PASSWORD }}
         run: pnpm run standard-site:sync
+      # always() so a partially-completed backfill still commits its progress.
       - name: Commit manifest changes
+        if: always()
         run: |
           if ! git diff --quiet standard-site.manifest.json; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add standard-site.manifest.json
-            git commit -m "chore: sync standard.site manifest [skip ci]"
+            # No [skip ci]: this lets Vercel deploy the manifest so the per-post
+            # <link> tags go live. The push touches only the manifest, which is
+            # outside this workflow's path filter, so it will not re-trigger here.
+            git commit -m "chore: sync standard.site manifest"
             git push
           else
             echo "Manifest unchanged."

--- a/scripts/standard-site/sync.mjs
+++ b/scripts/standard-site/sync.mjs
@@ -79,23 +79,35 @@ console.log(`Logged in as ${publisher.getDid()} via ${publisher.getPdsUrl()}`);
 
 const ctx = { siteUrl: config.siteUrl, transform: transformContent };
 
-for (const a of actions.create) {
-  const input = { site: config.siteUrl, ...a.source.toInput(a.entry, ctx) };
-  const res = await publisher.publishDocument(input);
-  manifest.documents[a.key] = { docUri: res.uri, docCid: res.cid, contentHash: a.hash };
-  console.log(`created ${a.key} → ${res.uri}`);
-}
-for (const a of actions.update) {
-  const input = { site: config.siteUrl, ...a.source.toInput(a.entry, ctx) };
-  const res = await publisher.updateDocument(a.rkey, input);
-  manifest.documents[a.key] = { docUri: res.uri, docCid: res.cid, contentHash: a.hash };
-  console.log(`updated ${a.key} → ${res.uri}`);
-}
-for (const a of actions.delete) {
-  await publisher.deleteDocument(a.rkey);
-  delete manifest.documents[a.key];
-  console.log(`deleted ${a.key}`);
+// Persist after every operation so a mid-run failure (network blip, rate limit)
+// never leaves published records unrecorded — a re-run resumes from here rather
+// than duplicating. The CI commit step runs with if: always() for the same reason.
+const persist = () =>
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n");
+
+try {
+  for (const a of actions.create) {
+    const input = { site: config.siteUrl, ...a.source.toInput(a.entry, ctx) };
+    const res = await publisher.publishDocument(input);
+    manifest.documents[a.key] = { docUri: res.uri, docCid: res.cid, contentHash: a.hash };
+    persist();
+    console.log(`created ${a.key} → ${res.uri}`);
+  }
+  for (const a of actions.update) {
+    const input = { site: config.siteUrl, ...a.source.toInput(a.entry, ctx) };
+    const res = await publisher.updateDocument(a.rkey, input);
+    manifest.documents[a.key] = { docUri: res.uri, docCid: res.cid, contentHash: a.hash };
+    persist();
+    console.log(`updated ${a.key} → ${res.uri}`);
+  }
+  for (const a of actions.delete) {
+    await publisher.deleteDocument(a.rkey);
+    delete manifest.documents[a.key];
+    persist();
+    console.log(`deleted ${a.key}`);
+  }
+} finally {
+  persist();
 }
 
-writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n");
 console.log(`\nWrote ${MANIFEST_PATH}.`);


### PR DESCRIPTION
## Summary
- Persist the manifest after every record operation (and in a `finally`), and run the CI commit step with `if: always()`, so a partially-completed backfill commits its progress rather than leaving published records unrecorded (which would risk duplicates on re-run).
- Drop `[skip ci]` from the manifest commit message so Vercel deploys it and the per-post `<link>` verification tags go live. The commit only touches `standard-site.manifest.json`, which is outside this workflow's path filter, so it does not re-trigger the workflow.
- Add a `workflow_dispatch` trigger for manual runs.

Merging this touches `scripts/standard-site/`, which triggers the workflow on `main` — with the `ATPROTO_APP_PASSWORD` secret now set, that performs the first backfill of all 108 posts.

## Test plan
- [ ] `pnpm run standard-site:sync -- --dry-run` lists 108 creates.
- [ ] After merge, the workflow run publishes 108 documents and commits the manifest.
- [ ] `curl https://joeinn.es/.well-known/site.standard.publication` returns the publication AT-URI; a published post's HTML carries `<link rel="site.standard.document">`.