### PR TITLE
Spec audit: SEO, accessibility, security & resilience

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import mdx from "@astrojs/mdx";
 import keystatic from "@keystatic/astro";
+import sitemap from "@astrojs/sitemap";
 
 import tailwindcss from "@tailwindcss/vite";
 
@@ -11,7 +12,8 @@ import vercel from "@astrojs/vercel";
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react(), mdx(), keystatic(), svelte()],
+  site: "https://joeinn.es",
+  integrations: [react(), mdx(), keystatic(), svelte(), sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "@astrojs/markdoc": "^0.15.5",
     "@astrojs/mdx": "^4.3.4",
     "@astrojs/react": "4.3.0",
+    "@astrojs/rss": "^4.0.18",
+    "@astrojs/sitemap": "^3.7.3",
     "@astrojs/svelte": "^7.1.0",
     "@astrojs/vercel": "^8.2.6",
     "@bryanguffey/astro-standard-site": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,31 +10,37 @@ importers:
     dependencies:
       '@astrojs/markdoc':
         specifier: ^0.15.5
-        version: 0.15.5(@types/react@19.1.8)(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)
+        version: 0.15.5(@types/react@19.1.8)(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)
       '@astrojs/mdx':
         specifier: ^4.3.4
-        version: 4.3.4(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))
+        version: 4.3.4(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))
       '@astrojs/react':
         specifier: 4.3.0
-        version: 4.3.0(@types/node@24.0.3)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.3.0(@types/node@24.12.4)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
+      '@astrojs/sitemap':
+        specifier: ^3.7.3
+        version: 3.7.3
       '@astrojs/svelte':
         specifier: ^7.1.0
-        version: 7.1.0(@types/node@24.0.3)(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.34.7)(typescript@5.8.3)
+        version: 7.1.0(@types/node@24.12.4)(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.34.7)(typescript@5.8.3)
       '@astrojs/vercel':
         specifier: ^8.2.6
-        version: 8.2.6(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)(rollup@4.44.0)(svelte@5.34.7)
+        version: 8.2.6(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)(rollup@4.44.0)(svelte@5.34.7)
       '@bryanguffey/astro-standard-site':
         specifier: ^1.0.3
-        version: 1.0.3(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))
+        version: 1.0.3(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))
       '@keystatic/astro':
         specifier: ^5.0.6
-        version: 5.0.6(@keystatic/core@0.5.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 5.0.6(@keystatic/core@0.5.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@keystatic/core':
         specifier: ^0.5.47
         version: 0.5.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.10
-        version: 4.1.10(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 4.1.10(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))
       '@types/react':
         specifier: ^19.0.8
         version: 19.1.8
@@ -43,7 +49,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       astro:
         specifier: ^5.13.2
-        version: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+        version: 5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
       html2canvas-pro:
         specifier: ^1.5.11
         version: 1.5.11
@@ -126,6 +132,12 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
+
+  '@astrojs/sitemap@3.7.3':
+    resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
 
   '@astrojs/svelte@7.1.0':
     resolution: {integrity: sha512-nNAO7iFgCZXCN31N4xBSS/k7vZAZxeZ/v8V6VWZOKG47gVlxeAJBHzn2GlXMMVkxIamr6dhrkDrhYFKIPzoGpw==}
@@ -834,6 +846,9 @@ packages:
 
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
+
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1709,6 +1724,9 @@ packages:
   '@types/node@24.0.3':
     resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
 
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -1719,6 +1737,9 @@ packages:
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1848,6 +1869,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2252,6 +2276,13 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
@@ -2956,6 +2987,10 @@ packages:
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -2976,6 +3011,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  piccolore@0.1.3:
+    resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3152,6 +3190,10 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -3206,6 +3248,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   slate-history@0.86.0:
     resolution: {integrity: sha512-OxObL9tbhgwvSlnKSCpGIh7wnuaqvOj5jRExGjEyCU2Ke8ctf22HjT+jw7GEi9ttLzNTUmTEU3YIzqKGeqN+og==}
     peerDependencies:
@@ -3243,6 +3290,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3269,6 +3319,9 @@ packages:
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -3379,6 +3432,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
@@ -3610,6 +3666,10 @@ packages:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -3682,6 +3742,9 @@ packages:
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -3700,13 +3763,13 @@ snapshots:
 
   '@astrojs/internal-helpers@0.7.2': {}
 
-  '@astrojs/markdoc@0.15.5(@types/react@19.1.8)(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)':
+  '@astrojs/markdoc@0.15.5(@types/react@19.1.8)(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.7.2
       '@astrojs/markdown-remark': 6.3.6
       '@astrojs/prism': 3.3.0
       '@markdoc/markdoc': 0.5.2(@types/react@19.1.8)(react@19.1.0)
-      astro: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+      astro: 5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
       esbuild: 0.25.5
       github-slugger: 2.0.0
       htmlparser2: 10.0.0
@@ -3741,12 +3804,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.4(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))':
+  '@astrojs/mdx@4.3.4(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.6
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       acorn: 8.15.0
-      astro: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+      astro: 5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3764,15 +3827,15 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@4.3.0(@types/node@24.0.3)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@astrojs/react@4.3.0(@types/node@24.12.4)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
-      '@vitejs/plugin-react': 4.6.0(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))
+      '@vitejs/plugin-react': 4.6.0(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       ultrahtml: 1.6.0
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3787,14 +3850,26 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/svelte@7.1.0(@types/node@24.0.3)(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.34.7)(typescript@5.8.3)':
+  '@astrojs/rss@4.0.18':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))
-      astro: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+      fast-xml-parser: 5.8.0
+      piccolore: 0.1.3
+      zod: 4.4.3
+
+  '@astrojs/sitemap@3.7.3':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.4.3
+
+  '@astrojs/svelte@7.1.0(@types/node@24.12.4)(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(jiti@2.4.2)(lightningcss@1.30.1)(svelte@5.34.7)(typescript@5.8.3)':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))
+      astro: 5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
       svelte: 5.34.7
       svelte2tsx: 0.7.40(svelte@5.34.7)(typescript@5.8.3)
       typescript: 5.8.3
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3821,14 +3896,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@8.2.6(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)(rollup@4.44.0)(svelte@5.34.7)':
+  '@astrojs/vercel@8.2.6(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react@19.1.0)(rollup@4.44.0)(svelte@5.34.7)':
     dependencies:
       '@astrojs/internal-helpers': 0.7.2
       '@vercel/analytics': 1.5.0(react@19.1.0)(svelte@5.34.7)
       '@vercel/functions': 2.2.12
       '@vercel/nft': 0.29.4(rollup@4.44.0)
       '@vercel/routing-utils': 5.0.8
-      astro: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+      astro: 5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
       esbuild: 0.25.5
       tinyglobby: 0.2.14
     transitivePeerDependencies:
@@ -4017,10 +4092,10 @@ snapshots:
 
   '@braintree/sanitize-url@6.0.4': {}
 
-  '@bryanguffey/astro-standard-site@1.0.3(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))':
+  '@bryanguffey/astro-standard-site@1.0.3(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))':
     dependencies:
       '@atproto/api': 0.15.27
-      astro: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+      astro: 5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
       zod: 3.25.67
 
   '@capsizecss/unpack@2.4.0':
@@ -4522,12 +4597,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@keystatic/astro@5.0.6(@keystatic/core@0.5.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@keystatic/astro@5.0.6(@keystatic/core@0.5.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.6
       '@keystatic/core': 0.5.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/react': 19.1.8
-      astro: 5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
+      astro: 5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       set-cookie-parser: 2.7.1
@@ -4665,6 +4740,8 @@ snapshots:
     transitivePeerDependencies:
       - acorn
       - supports-color
+
+  '@nodable/entities@2.1.1': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -5713,25 +5790,25 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.34.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.34.7)(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))
+      '@sveltejs/vite-plugin-svelte': 5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))
       debug: 4.4.1
       svelte: 5.34.7
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.34.7)(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.7)(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.34.7)(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))
       debug: 4.4.1
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.34.7
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
-      vitefu: 1.0.7(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
+      vitefu: 1.0.7(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -5811,12 +5888,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.10
 
-  '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@tailwindcss/vite@4.1.10(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@tailwindcss/node': 4.1.10
       '@tailwindcss/oxide': 4.1.10
       tailwindcss: 4.1.10
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
 
   '@toeverything/y-indexeddb@0.10.0-canary.9(yjs@13.6.27)':
     dependencies:
@@ -5902,6 +5979,10 @@ snapshots:
     dependencies:
       undici-types: 7.8.0
 
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/parse-json@4.0.2': {}
 
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
@@ -5911,6 +5992,10 @@ snapshots:
   '@types/react@19.1.8':
     dependencies:
       csstype: 3.1.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 24.12.4
 
   '@types/unist@2.0.11': {}
 
@@ -5983,7 +6068,7 @@ snapshots:
     optionalDependencies:
       ajv: 6.12.6
 
-  '@vitejs/plugin-react@4.6.0(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@vitejs/plugin-react@4.6.0(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@babel/core': 7.27.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.4)
@@ -5991,7 +6076,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6036,6 +6121,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  arg@5.0.2: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -6052,7 +6139,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@5.13.2(@types/node@24.0.3)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3):
+  astro@5.13.2(@types/node@24.12.4)(idb-keyval@6.2.2)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.0)(typescript@5.8.3):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.7.2
@@ -6108,8 +6195,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.16.0(idb-keyval@6.2.2)
       vfile: 6.0.3
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
-      vitefu: 1.0.7(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1))
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
+      vitefu: 1.0.7(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -6508,6 +6595,19 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0:
     optional: true
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
 
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
@@ -7519,6 +7619,8 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -7533,6 +7635,8 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
+
+  piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
 
@@ -7812,6 +7916,8 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  sax@1.6.0: {}
+
   scheduler@0.26.0: {}
 
   scroll-into-view-if-needed@2.2.31:
@@ -7913,6 +8019,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.12.4
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.6.0
+
   slate-history@0.86.0(slate@0.91.4):
     dependencies:
       is-plain-object: 5.0.0
@@ -7951,6 +8064,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stream-replace-string@2.0.0: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -7983,6 +8098,8 @@ snapshots:
       ansi-regex: 6.1.0
 
   strip-bom-string@1.0.0: {}
+
+  strnum@2.3.0: {}
 
   style-to-js@1.1.17:
     dependencies:
@@ -8083,6 +8200,8 @@ snapshots:
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
+
+  undici-types@7.16.0: {}
 
   undici-types@7.8.0: {}
 
@@ -8215,7 +8334,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1):
+  vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -8224,14 +8343,14 @@ snapshots:
       rollup: 4.44.0
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.0.3
+      '@types/node': 24.12.4
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
 
-  vitefu@1.0.7(vite@6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)):
+  vitefu@1.0.7(vite@6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)
 
   w3c-keyname@2.2.8: {}
 
@@ -8273,6 +8392,8 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 7.2.0
       strip-ansi: 7.1.0
+
+  xml-naming@0.1.0: {}
 
   xxhash-wasm@1.1.0: {}
 
@@ -8326,5 +8447,7 @@ snapshots:
       zod: 3.25.67
 
   zod@3.25.67: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+# Security contact details for joeinn.es
+Contact: mailto:joe@joeinn.es
+Expires: 2027-06-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://joeinn.es/.well-known/security.txt

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,19 @@
+# Joe Innes
+
+> Personal website and blog for Joe Innes (joeinn.es): long-form writing, short-form notes, a log of open source contributions, and ways to get in touch.
+
+## Pages
+
+- [Home](https://joeinn.es/): Landing page with name, tagline, and hero image.
+- [CV](https://joeinn.es/cv): Curriculum vitae, viewable inline and available to download as a PDF.
+- [Now](https://joeinn.es/now): What Joe is focused on right now, plus recently played tracks.
+- [Contact](https://joeinn.es/contact): Get in touch via the contact form.
+
+## Writing
+
+- [Blog](https://joeinn.es/blog): Long-form blog posts, with client-side search by title.
+- [Smidgeons](https://joeinn.es/smidgeons): Short-form notes and quick thoughts, paginated.
+
+## Open source
+
+- [I Shipped](https://joeinn.es/i-shipped): Log of open source contributions, grouped by date with expandable details for each merged pull request.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://joeinn.es/sitemap-index.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-	"name": "",
-	"short_name": "",
+	"name": "Joe Innes",
+	"short_name": "Joe Innes",
 	"icons": [
 		{ "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
 		{ "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,0 +1,75 @@
+---
+export interface Props {
+  title: string;
+  description?: string;
+  image?: string;
+  type?: "website" | "article";
+}
+
+const DEFAULT_DESCRIPTION =
+  "Joe Innes — full-stack developer helping people build local-first, realtime apps with encrypted, distributed data.";
+const DEFAULT_IMAGE = "/joei.webp";
+
+const {
+  title,
+  description = DEFAULT_DESCRIPTION,
+  image = DEFAULT_IMAGE,
+  type = "website",
+} = Astro.props;
+
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+const imageUrl = new URL(image, Astro.site).href;
+---
+
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<title>{title}</title>
+<meta name="description" content={description} />
+
+<link rel="canonical" href={canonicalUrl} />
+
+<meta name="color-scheme" content="light dark" />
+<meta
+  name="theme-color"
+  media="(prefers-color-scheme: light)"
+  content="#ffffff"
+/>
+<meta
+  name="theme-color"
+  media="(prefers-color-scheme: dark)"
+  content="#000000"
+/>
+
+<link rel="icon" href="/favicon.ico" sizes="any" />
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+<link rel="manifest" href="/site.webmanifest" />
+
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title="Joe Innes — Blog"
+  href="/rss.xml"
+/>
+
+<meta property="og:type" content={type} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:url" content={canonicalUrl} />
+<meta property="og:image" content={imageUrl} />
+<meta property="og:site_name" content="Joe Innes" />
+
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={imageUrl} />
+
+<meta name="generator" content={Astro.generator} />
+
+<link rel="preconnect" href="https://fonts.bunny.net" />
+<link
+  href="https://fonts.bunny.net/css?family=space-grotesk:400,700|space-mono:400,700&display=swap"
+  rel="stylesheet"
+/>

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -15,6 +15,7 @@
       <li><a href="/contact">Contact</a></li>
       <li><a href="/smidgeons">Smidgeons</a></li>
       <li><a href="/now">Now</a></li>
+      <li><a href="/privacy">Privacy</a></li>
     </ul>
   </div>
   <div class="p-4">

--- a/src/components/NewNav.astro
+++ b/src/components/NewNav.astro
@@ -105,7 +105,10 @@ const links: { href: string; label: string }[] = [
 
 <details>
   <summary
+    aria-label="Menu"
     ><svg
+      aria-hidden="true"
+      focusable="false"
       height="1em"
       style="enable-background:new 0 0 32 32;"
       version="1.1"

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -1,14 +1,18 @@
 ---
 import "../styles.css";
+import BaseHead from "../components/BaseHead.astro";
 import NowPlaying from "../components/NowPlaying.svelte";
 import { ClientRouter } from "astro:transitions";
 
 export interface Props {
   title: string;
   bg?: string;
+  description?: string;
+  image?: string;
+  type?: "website" | "article";
 }
 
-const { title, bg } = Astro.props;
+const { title, bg, description, image, type } = Astro.props;
 ---
 
 <!doctype html>
@@ -19,21 +23,47 @@ const { title, bg } = Astro.props;
 }`}
 >
   <head>
-    <meta charset="UTF-8" />
-    <meta name="description" content="Astro description" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="preconnect" href="https://fonts.bunny.net" />
-    <link
-      href="https://fonts.bunny.net/css?family=space-grotesk:400,700|space-mono:400,700"
-      rel="stylesheet"
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      type={type}
     />
-    <meta name="generator" content={Astro.generator} />
-    <title>{title}</title>
     <ClientRouter />
     <slot name="head" />
   </head>
   <body>
-    <slot />
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <div id="main-content" tabindex="-1">
+      <slot />
+    </div>
     <NowPlaying client:load />
+    <style>
+      .skip-link {
+        position: absolute;
+        inset-inline-start: 0;
+        inset-block-start: 0;
+        transform: translateY(-100%);
+        padding: 0.5rem 1rem;
+        background: var(--background, #fff);
+        color: var(--foreground, #000);
+        z-index: 1000;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        overflow: hidden;
+        white-space: nowrap;
+      }
+
+      .skip-link:focus {
+        transform: translateY(0);
+        clip: auto;
+        clip-path: none;
+        overflow: visible;
+      }
+
+      #main-content:focus {
+        outline: none;
+      }
+    </style>
   </body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,27 +1,31 @@
 ---
 import "../styles/global.css";
 
+import BaseHead from "../components/BaseHead.astro";
 import Nav from "../components/nav.astro";
 import Footer from "../components/Footer.svelte";
 
 export interface Props {
   title: string;
   bg?: string;
+  description?: string;
+  image?: string;
+  type?: "website" | "article";
 }
 
-const { title, bg } = Astro.props;
+const { title, bg, description, image, type } = Astro.props;
 const { pathname } = Astro.url;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="description" content="Astro description" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.png" />
-    <meta name="generator" content={Astro.generator} />
-    <title>{title}</title>
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      type={type}
+    />
   </head>
   <body
     style={`background: ${bg}`}
@@ -29,10 +33,42 @@ const { pathname } = Astro.url;
       ? "flex flex-col justify-center h-screen pt-0"
       : "flex flex-col pt-24 h-screen"}
   >
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <Nav />
-    <div class={pathname === "/" ? "" : "flex-1 flex flex-col"}>
+    <div
+      id="main-content"
+      tabindex="-1"
+      class={pathname === "/" ? "" : "flex-1 flex flex-col"}
+    >
       <slot />
     </div>
     {pathname !== "/" && <Footer />}
+    <style>
+      .skip-link {
+        position: absolute;
+        inset-inline-start: 0;
+        inset-block-start: 0;
+        transform: translateY(-100%);
+        padding: 0.5rem 1rem;
+        background: #fff;
+        color: #000;
+        z-index: 1000;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        overflow: hidden;
+        white-space: nowrap;
+      }
+
+      .skip-link:focus {
+        transform: translateY(0);
+        clip: auto;
+        clip-path: none;
+        overflow: visible;
+      }
+
+      #main-content:focus {
+        outline: none;
+      }
+    </style>
   </body>
 </html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,37 @@
+---
+import Layout from "../layouts/Default.astro";
+import Nav from "../components/NewNav.astro";
+
+const description =
+  "Sorry, the page you were looking for could not be found.";
+---
+
+<Layout title="Joe Innes | Page not found" description={description}>
+  <Nav />
+  <main>
+    <h1 class="title">Page not found</h1>
+    <p>
+      Sorry, the page you were after seems to have wandered off. It might have
+      been moved, renamed, or perhaps it never existed in the first place.
+    </p>
+    <p>
+      Let's get you back on track — head to the
+      <a href="/">home page</a> or take a look at the
+      <a href="/blog">blog</a>.
+    </p>
+  </main>
+</Layout>
+
+<style>
+  main {
+    max-width: 60ch;
+  }
+
+  p {
+    margin-block: 1rem;
+  }
+
+  a {
+    color: var(--primary);
+  }
+</style>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -24,6 +24,28 @@ const linkTag = docRkey
   : null;
 const canonicalUrl = `${siteConfig.siteUrl}/blog/${post.slug}`;
 
+const pageUrl = new URL(`/blog/${post.slug}`, Astro.site).href;
+const absoluteImage = post.data.featured_image
+  ? new URL(post.data.featured_image, Astro.site).href
+  : undefined;
+
+const blogPostingJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: post.data.title,
+  datePublished: new Date(post.data.date).toISOString(),
+  dateModified: new Date(
+    post.data.date_updated ?? post.data.date,
+  ).toISOString(),
+  author: {
+    "@type": "Person",
+    name: "Joe Innes",
+  },
+  mainEntityOfPage: pageUrl,
+  ...(absoluteImage ? { image: absoluteImage } : {}),
+  ...(post.data.excerpt ? { description: post.data.excerpt } : {}),
+};
+
 // Generate static pages
 export async function getStaticPaths() {
   const posts = await getCollection("posts");
@@ -36,10 +58,21 @@ export async function getStaticPaths() {
     margin-block-end: var(--layout-spacing);
   }
 </style>
-<Layout title={post.data.title} bg={post.data.page_bg}>
+<Layout
+  title={post.data.title}
+  bg={post.data.page_bg}
+  description={post.data.excerpt}
+  image={post.data.featured_image}
+  type="article"
+>
   {linkTag && <Fragment slot="head" set:html={linkTag} />}
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify(blogPostingJsonLd)}
+    slot="head"
+  />
+  <Nav />
   <main>
-    <Nav />
     <hgroup class="content meta">
       <h1 class="title" transition:name={`post-title-${post.slug}`}>
         {post.data.title}
@@ -64,7 +97,12 @@ export async function getStaticPaths() {
               "https://source.unsplash.com/random/?" +
                 encodeURIComponent(post.data.title)
             }
-            style="width: 100%; aspect-ratio: 16/9; object-fit: cover; margin-block-end: var(--layout-spacing);"
+            width="1200"
+            height="675"
+            decoding="async"
+            loading="eager"
+            fetchpriority="high"
+            style="width: 100%; height: auto; aspect-ratio: 16/9; object-fit: cover; margin-block-end: var(--layout-spacing);"
           />
         </div>
       )

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,6 +9,9 @@ const filteredPosts = await getCollection("posts", ({ data }) => {
   return !data.draft && new Date(data.date) < now;
 });
 const dateSort = (a, b) => new Date(b.data.date) - new Date(a.data.date);
+
+const description =
+  "Long-form writing from Joe Innes on local-first software, realtime sync, encrypted distributed data, and building for the web.";
 ---
 
 <style>
@@ -79,7 +82,7 @@ const dateSort = (a, b) => new Date(b.data.date) - new Date(a.data.date);
   }
 </style>
 
-<Layout title="Joe Innes | Blog">
+<Layout title="Joe Innes | Blog" description={description}>
   <Nav />
   <main>
     <h1 class="title">Joe Innes's Blog</h1>
@@ -102,6 +105,7 @@ const dateSort = (a, b) => new Date(b.data.date) - new Date(a.data.date);
       <input
         id="search"
         type="text"
+        aria-label="Search posts"
         placeholder={`Search (e.g.: ${posts[Math.floor(Math.random() * posts.length)]?.data.title})`}
       />
     </label>

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -1,9 +1,12 @@
 ---
 import Layout from "../../layouts/Default.astro";
 import Nav from "../../components/NewNav.astro";
+
+const description =
+  "Get in touch with Joe Innes. Drop a message about projects, collaboration, or anything else using the contact form.";
 ---
 
-<Layout title="Joe Innes | Contact">
+<Layout title="Joe Innes | Contact" description={description}>
   <Nav />
   <main>
     <h1 class="title">Contact</h1>

--- a/src/pages/cv/index.astro
+++ b/src/pages/cv/index.astro
@@ -1,6 +1,9 @@
 ---
 import Layout from "../../layouts/Default.astro";
 import Nav from "../../components/NewNav.astro";
+
+const description =
+  "Joe Innes's CV — full-stack developer experience, skills, and history. Download a PDF copy or request a different format.";
 ---
 
 <style>
@@ -31,7 +34,7 @@ import Nav from "../../components/NewNav.astro";
   }
 </style>
 
-<Layout title="Joe Innes">
+<Layout title="Joe Innes | CV" description={description}>
   <Nav />
   <main>
     <h1 class="title">My CV</h1>

--- a/src/pages/i-shipped/[...page].astro
+++ b/src/pages/i-shipped/[...page].astro
@@ -55,6 +55,9 @@ export async function getStaticPaths() {
     })),
   ];
 }
+
+const description =
+  "Open source contributions from Joe Innes — a running log of merged pull requests and the projects they shipped to.";
 ---
 
 <style>
@@ -148,10 +151,9 @@ export async function getStaticPaths() {
   }
 </style>
 
-<Layout title="I Shipped...">
+<Layout title="I Shipped..." description={description}>
+  <Nav />
   <main class="mono">
-    <Nav />
-
     <h1 class="title">I Shipped...</h1>
     {
       Object.entries(groupedByDate).map(async ([dateKey, items]) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,16 +3,34 @@ import { Image } from "astro:assets";
 import joeImage from "../../public/joei.webp";
 import Layout from "../layouts/Default.astro";
 import NewNav from "../components/NewNav.astro";
+
+const description =
+  "Joe Innes is a full-stack developer helping people build local-first, realtime apps with encrypted, distributed data.";
+
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Joe Innes",
+  jobTitle: "Full Stack Developer",
+  url: "https://joeinn.es",
+  image: new URL("/joei.webp", Astro.site).href,
+  sameAs: ["https://bsky.app/profile/joeinn.es"],
+};
 ---
 
-<Layout title="Joe Innes">
+<Layout title="Joe Innes" description={description}>
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify(personJsonLd)}
+    slot="head"
+  />
   <style>
     h1 + p {
       font-size: 1.5em;
     }
   </style>
+  <NewNav />
   <main>
-    <NewNav />
     <h1 class="title">Joe Innes</h1>
     <p class="mono">Full Stack Developer</p>
     <Image

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -9,11 +9,14 @@ const now = await reader.singletons.now.read();
 const content = await now?.now();
 const renderedMd = await marked.parse(content || "");
 import RecentTracks from "../../components/RecentTracks.svelte";
+
+const description =
+  "What Joe Innes is focused on right now — current projects, priorities, and recent listening.";
 ---
 
-<Layout title="Joe Innes | Now">
+<Layout title="Joe Innes | Now" description={description}>
+  <Nav />
   <main>
-    <Nav />
     <h1 class="title">Now</h1>
     <article set:html={renderedMd} />
     <article>

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -1,0 +1,66 @@
+---
+import Layout from "../../layouts/Default.astro";
+import Nav from "../../components/NewNav.astro";
+
+const description =
+  "How joeinn.es handles your data: no tracking cookies, no analytics, and a short list of privacy-friendly third-party services.";
+---
+
+<Layout title="Joe Innes | Privacy" description={description}>
+  <Nav />
+  <main>
+    <h1 class="title">Privacy</h1>
+    <p>
+      This is a personal website, and I&rsquo;ve tried to keep it as
+      privacy-respecting as I can. It sets no tracking cookies and runs no
+      analytics &mdash; I don&rsquo;t measure who you are or what you do here.
+    </p>
+    <p>
+      A handful of third-party services are involved in making the site work.
+      Here&rsquo;s the full list, and what each one sees.
+    </p>
+
+    <h2>Contact form</h2>
+    <p>
+      The <a href="/contact">contact form</a> is handled by
+      <a href="https://formspree.io/legal/privacy-policy/"
+        >Formspree</a
+      >. When you submit it, the email address, subject, and message you enter
+      are passed to Formspree, which forwards them on to me. I only use what you
+      send to reply to you.
+    </p>
+
+    <h2>Web fonts</h2>
+    <p>
+      Fonts are served from
+      <a href="https://bunny.net/privacy/">fonts.bunny.net</a>, a
+      privacy-friendly font CDN that does not log personal data or set cookies.
+      Loading a font does reveal your IP address to the CDN, as any network
+      request would.
+    </p>
+
+    <h2>Now playing and comments</h2>
+    <p>
+      The &ldquo;now playing&rdquo; widget and the comments on blog posts read
+      public data from the
+      <a href="https://atproto.com/">AT Protocol</a> network (Bluesky). These
+      requests go to public Bluesky endpoints from your browser; as with any
+      request, the endpoint can see your IP address. No account or sign-in is
+      required to view them.
+    </p>
+
+    <h2>Hosting</h2>
+    <p>
+      The site is hosted on <a href="https://vercel.com/legal/privacy-policy"
+        >Vercel</a
+      >, which may process standard server request data (such as your IP
+      address) in order to serve pages.
+    </p>
+
+    <h2>Questions</h2>
+    <p>
+      If you&rsquo;d like to know more, or want me to delete a message you sent
+      via the contact form, just <a href="/contact">get in touch</a>.
+    </p>
+  </main>
+</Layout>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,0 +1,26 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+
+export async function GET(context) {
+  const now = new Date();
+  const posts = await getCollection("posts", ({ data }) => {
+    return !data.draft && new Date(data.date) < now;
+  });
+
+  const sortedPosts = posts.sort(
+    (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf(),
+  );
+
+  return rss({
+    title: "Joe Innes — Blog",
+    description:
+      "Writing from Joe Innes on local-first, realtime apps, encrypted distributed data, and web development.",
+    site: context.site,
+    items: sortedPosts.map((post) => ({
+      title: post.data.title,
+      link: `/blog/${post.slug}`,
+      pubDate: post.data.date,
+      description: post.data.excerpt,
+    })),
+  });
+}

--- a/src/pages/smidgeons/[...page].astro
+++ b/src/pages/smidgeons/[...page].astro
@@ -35,6 +35,9 @@ export async function getStaticPaths() {
 
   return paths;
 }
+
+const description =
+  "Smidgeons from Joe Innes — short-form notes, snippets, and passing thoughts, inspired by Maggie Appleton.";
 ---
 
 <style>
@@ -57,7 +60,7 @@ export async function getStaticPaths() {
   }
 </style>
 
-<Layout title="Joe Innes | Smidgeons">
+<Layout title="Joe Innes | Smidgeons" description={description}>
   <Nav />
   <main>
     <h1 class="title">Smidgeons</h1>

--- a/vercel.json
+++ b/vercel.json
@@ -26,7 +26,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src 'self' https://fonts.bunny.net data:; script-src 'self' 'unsafe-inline'; connect-src 'self' https://bsky.social https://public.api.bsky.app https://coverartarchive.org https://api.open-meteo.com https://api.joeinn.es; frame-src https://www.openstreetmap.org; form-action 'self' https://formspree.io; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'self'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src 'self' https://fonts.bunny.net data:; script-src 'self' 'unsafe-inline'; connect-src 'self' https://bsky.social https://public.api.bsky.app https://coverartarchive.org https://api.open-meteo.com https://api.joeinn.es; frame-src 'self' https://www.youtube.com https://www.openstreetmap.org; form-action 'self' https://formspree.io; upgrade-insecure-requests"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), browsing-topics=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src 'self' https://fonts.bunny.net data:; script-src 'self' 'unsafe-inline'; connect-src 'self' https://bsky.social https://public.api.bsky.app https://coverartarchive.org https://api.open-meteo.com https://api.joeinn.es; frame-src https://www.openstreetmap.org; form-action 'self' https://formspree.io; upgrade-insecure-requests"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Specification audit for joeinn.es

Implements the 20 `joe-*` tickets from auditing the site against [The Website Specification](https://specification.website/). All changes verified with a green `pnpm build`.

### Foundations & SEO
- Set `site` in `astro.config.mjs`; self-referencing `rel=canonical` site-wide (joe-66fd, joe-8bbf)
- Real per-page `<meta name="description">` — replaces the hardcoded `"Astro description"` placeholder (joe-8acf)
- Open Graph + Twitter Card tags via a new shared `BaseHead.astro` (joe-26c6)
- `color-scheme` + light/dark `theme-color`, favicon / apple-touch / manifest links; fixed the empty web manifest (joe-309e, joe-fdd5)
- XML sitemap (`@astrojs/sitemap`) + `Sitemap:` in robots.txt; RSS feed at `/rss.xml` with `rel=alternate` discovery (joe-f451, joe-3692)
- JSON-LD: `Person` on the homepage, `BlogPosting` on posts (joe-cfac)

### Accessibility
- Accessible name on the hamburger toggle (joe-88d0)
- Skip-to-content link (joe-de18)
- Accessible label on the blog search input (joe-921d)
- Moved `nav` out of `<main>` on four pages (joe-8c3a)
- Explicit dimensions + `fetchpriority` on the post hero image to remove CLS (joe-f847)

### Security & resilience
- `vercel.json` baseline headers: HSTS, CSP, `nosniff`, `frame-ancestors`, Referrer-Policy, Permissions-Policy (joe-78c0)
- `/.well-known/security.txt` (joe-2678)
- Custom 404 page (joe-dedc); privacy policy + footer link (joe-ee53)

### Agent readiness
- `/llms.txt` (joe-2dd6)

### Fonts
- `display=swap` on the bunny.net stylesheet (joe-b9a6)

## ⚠️ Before deploying
- **CSP**: relies on `'unsafe-inline'` for script/style (Astro + Svelte islands need it). Suggest shipping as `Content-Security-Policy-Report-Only` first, then tightening to nonces/hashes. `connect-src`/`frame-src` were derived from the actual widget hosts (bsky.social, coverartarchive.org, open-meteo, openstreetmap, formspree).
- Dead `data-umami-event` attribute on the CV link with no umami script loaded — the privacy page states "no analytics", so remove the attribute or wire up umami.
- Fully non-blocking fonts would need self-hosting the woff2 (follow-up).

## Notes
No test harness exists in the repo, so changes were verified by build + output inspection rather than red/green TDD.