### PR TITLE
add i-shipped entries for 5 new merged PRs (June 2026)

### DIFF
--- a/src/content/i-shipped/a-fix-for-a-permissions-head-before-bundle-race-causing-local-write-denials.mdx
+++ b/src/content/i-shipped/a-fix-for-a-permissions-head-before-bundle-race-causing-local-write-denials.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a permissions head-before-bundle race causing local write denials
+repo: garden-co/jazz
+mergeDate: 2026-06-02
+prNumber: '975'
+---
+When the permission header for a piece of data arrived before the data itself, Jazz was incorrectly rejecting local writes. I removed a redundant authorization call so that Jazz waits until the full data bundle is received before enforcing permissions, eliminating a race condition that caused intermittent test failures in CI.

--- a/src/content/i-shipped/a-fix-for-admin-secrets-being-exposed-in-server-startup-logs.mdx
+++ b/src/content/i-shipped/a-fix-for-admin-secrets-being-exposed-in-server-startup-logs.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for admin secrets being exposed in server startup logs
+repo: garden-co/jazz
+mergeDate: 2026-06-02
+prNumber: '981'
+---
+The Jazz server was logging its full inspector URL at startup, which had the admin secret embedded directly in the link — meaning anyone with access to the logs could see the credential. I removed the secret from the logged URL and added a warning that fires when the server starts without production auth settings configured, so developers aren't silently running in an open state.

--- a/src/content/i-shipped/a-fix-for-declaration-files-being-emitted-outside-declarationdir-in-sveltes-language-tools.mdx
+++ b/src/content/i-shipped/a-fix-for-declaration-files-being-emitted-outside-declarationdir-in-sveltes-language-tools.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  a fix for declaration files being emitted outside declarationDir in Svelte's language tools
+repo: sveltejs/language-tools
+mergeDate: 2026-06-01
+prNumber: '2965'
+---
+When a Svelte component imported a TypeScript file from outside the configured source root, the `emitDts` tool would create `.d.ts` type declaration files in the wrong place — sometimes nesting them deep in the source tree with doubled absolute paths. I fixed the file-writing hook to skip any declarations that fall outside the intended output directory and to only prepend relative path prefixes when the filename is already relative.

--- a/src/content/i-shipped/an-end-to-end-test-harness-for-jazz-starter-templates.mdx
+++ b/src/content/i-shipped/an-end-to-end-test-harness-for-jazz-starter-templates.mdx
@@ -1,0 +1,7 @@
+---
+summary: an end-to-end test harness for Jazz starter templates
+repo: garden-co/jazz
+mergeDate: 2026-06-02
+prNumber: '978'
+---
+Individual starter tests ran against dev builds and missed regressions that only showed up at release time. I built a new testing package that scaffolds each of the 12 starters using the real CLI, installs dependencies, builds for production, and runs all Playwright tests against the production build — all gated in CI before any release goes out.

--- a/src/content/i-shipped/type-checking-for-docs-example-snippets-in-the-build-pipeline.mdx
+++ b/src/content/i-shipped/type-checking-for-docs-example-snippets-in-the-build-pipeline.mdx
@@ -1,0 +1,7 @@
+---
+summary: type-checking for docs example snippets in the build pipeline
+repo: garden-co/jazz
+mergeDate: 2026-06-02
+prNumber: '979'
+---
+Broken code examples in the Jazz docs were shipping silently because they weren't type-checked. I wired TypeScript checking for all six docs example packages into the build pipeline, which also surfaced a bunch of existing errors in the snippets — wrong function signatures, renamed components, non-existent columns — that I fixed at the same time.


### PR DESCRIPTION
Adds 5 new i-shipped entries for PRs merged since the last update (2026-05-28):

- **garden-co/jazz #975**: fix for a permissions head-before-bundle race causing local write denials
- **garden-co/jazz #978**: end-to-end test harness for Jazz starter templates
- **garden-co/jazz #979**: type-checking for docs example snippets in the build pipeline
- **garden-co/jazz #981**: fix for admin secrets being exposed in server startup logs
- **sveltejs/language-tools #2965**: fix for declaration files being emitted outside declarationDir

---
_Generated by [Claude Code](https://claude.ai/code/session_0194T14b31nLkiYWEWmqNomk)_