### PR TITLE
add 38 new i-shipped entries (jazz, brightblur, bearli)

### DIFF
--- a/src/content/i-shipped/a-backlog-sweep-resolving-47-tickets-with-code-review-follow-ups.mdx
+++ b/src/content/i-shipped/a-backlog-sweep-resolving-47-tickets-with-code-review-follow-ups.mdx
@@ -1,0 +1,7 @@
+---
+summary: a backlog sweep resolving 47 tickets with code-review follow-ups
+repo: joeinnes/bearli
+mergeDate: 2026-06-04
+prNumber: '1'
+---
+I worked through the entire bearli backlog — 45 original tickets plus 2 more raised during an in-between multi-agent code review — resolving all of them in a single sweep. The code review caught several regressions mid-way through before they could ship.

--- a/src/content/i-shipped/a-ci-build-gate-with-scheduled-handler-validation.mdx
+++ b/src/content/i-shipped/a-ci-build-gate-with-scheduled-handler-validation.mdx
@@ -1,0 +1,7 @@
+---
+summary: a CI build gate with scheduled-handler validation
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '49'
+---
+I fixed brightblur's CI so it actually runs the Cloudflare adapter build, verifies the model checksums, and validates that the scheduled-task handler was injected correctly. Before this, the build and handler injection steps only ran at deploy time, so broken builds weren't caught until they were about to go to production.

--- a/src/content/i-shipped/a-ci-upgrade-to-node-24-ahead-of-node-20-deprecation.mdx
+++ b/src/content/i-shipped/a-ci-upgrade-to-node-24-ahead-of-node-20-deprecation.mdx
@@ -1,0 +1,7 @@
+---
+summary: a CI upgrade to Node 24 ahead of Node 20 deprecation
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '50'
+---
+I opted brightblur's GitHub Actions workflows into Node 24 before GitHub deprecated Node 20 on 16 June 2026, so the CI actions (checkout, setup-node, pnpm install) all run on the new runtime without warnings or failures.

--- a/src/content/i-shipped/a-cleanup-of-dead-apex-routes-from-the-staging-deploy-config.mdx
+++ b/src/content/i-shipped/a-cleanup-of-dead-apex-routes-from-the-staging-deploy-config.mdx
@@ -1,0 +1,7 @@
+---
+summary: a cleanup of dead apex routes from the staging deploy config
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '56'
+---
+I removed duplicate `brightblur.app` apex domain routes from the staging Cloudflare Worker config that were left over after disabling automatic branch deploys. They served no purpose without branch deploys and were cluttering the configuration.

--- a/src/content/i-shipped/a-docs-correction-for-the-production-secrets-worker-topology.mdx
+++ b/src/content/i-shipped/a-docs-correction-for-the-production-secrets-worker-topology.mdx
@@ -1,0 +1,7 @@
+---
+summary: a docs correction for the production secrets worker topology
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '53'
+---
+I corrected an error in brightblur's deployment docs that claimed `wrangler secret put --env production` targets a separate worker that doesn't serve the domain — it doesn't. The docs now accurately describe how Cloudflare Worker environments and secrets work together.

--- a/src/content/i-shipped/a-fix-for-a-missing-env-var-crashing-the-whole-site.mdx
+++ b/src/content/i-shipped/a-fix-for-a-missing-env-var-crashing-the-whole-site.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a missing env var crashing the whole site
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '51'
+---
+Production was returning a 500 error on every single request because the environment validator ran at the top of the request handler and threw an uncaught error when `CRON_SECRET` was missing. I fixed the validator so a missing non-critical env var no longer takes down the whole site.

--- a/src/content/i-shipped/a-fix-for-people-tab-back-navigation-and-feed-refetch.mdx
+++ b/src/content/i-shipped/a-fix-for-people-tab-back-navigation-and-feed-refetch.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for People tab back navigation and feed refetch
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '70'
+---
+I fixed two issues on the People page: the Back button now works correctly after switching tabs because navigation uses `pushState` to add a history entry, and each tab's feed is memoised so switching between tabs no longer throws away the loaded data and re-fetches it from scratch.

--- a/src/content/i-shipped/a-fix-for-stale-seeds-after-key-rotation-and-zeroing-of-split-key-halves.mdx
+++ b/src/content/i-shipped/a-fix-for-stale-seeds-after-key-rotation-and-zeroing-of-split-key-halves.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for stale seeds after key rotation and zeroing of split-key halves
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '59'
+---
+I fixed two encryption issues: after a key rotation, the unlock flow now reads the new seed from storage without requiring a logout, and the two halves of the intersection split-key are now zeroed from memory immediately after being combined — so they're not sitting around longer than necessary.

--- a/src/content/i-shipped/a-fix-for-the-person-page-crash-and-cramped-toast.mdx
+++ b/src/content/i-shipped/a-fix-for-the-person-page-crash-and-cramped-toast.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for the person-page crash and cramped toast notifications
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '86'
+---
+I fixed two bugs: the person page was crashing with a "Something went wrong" error because a reactive cache write was happening inside a Svelte `$derived` block (which Svelte forbids), and the toast notifications were too cramped on smaller screens.

--- a/src/content/i-shipped/a-fix-to-always-apply-the-watermark-before-displaying-decrypted-images.mdx
+++ b/src/content/i-shipped/a-fix-to-always-apply-the-watermark-before-displaying-decrypted-images.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix to always apply the watermark before displaying decrypted images
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '55'
+---
+Brightblur embeds an invisible per-viewer steganographic watermark in each photo at render time. I fixed a bug where the decrypted image URL was being published to the page before the watermark had been applied, meaning there was a window where an unwatermarked photo could be seen or captured.

--- a/src/content/i-shipped/a-guard-for-out-of-order-search-responses-and-date-person-filter-controls.mdx
+++ b/src/content/i-shipped/a-guard-for-out-of-order-search-responses-and-date-person-filter-controls.mdx
@@ -1,0 +1,7 @@
+---
+summary: a guard for out-of-order search responses and date/person filter controls
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '62'
+---
+I fixed a race condition where a slow search response could arrive after a newer one and overwrite the results with stale data — each request now carries a sequence token so out-of-order responses are silently discarded. I also added date-range and person filter controls to the search UI.

--- a/src/content/i-shipped/a-mark-all-as-read-control-and-push-subscription-ownership-verification.mdx
+++ b/src/content/i-shipped/a-mark-all-as-read-control-and-push-subscription-ownership-verification.mdx
@@ -1,0 +1,7 @@
+---
+summary: a mark-all-as-read control and push-subscription ownership verification
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '67'
+---
+I added a "Mark all as read" button to the notifications panel that clears every unread notification at once. I also fixed a security issue where a push notification subscription from a previous user on a shared device could be incorrectly re-bound to the new user — it's now unsubscribed instead.

--- a/src/content/i-shipped/a-paginated-indexed-admin-reports-queue-with-an-audit-trail.mdx
+++ b/src/content/i-shipped/a-paginated-indexed-admin-reports-queue-with-an-audit-trail.mdx
@@ -1,0 +1,7 @@
+---
+summary: a paginated, indexed admin reports queue with an audit trail
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '63'
+---
+I overhauled brightblur's content moderation queue: reports are now paginated with a database index so it stays fast as reports accumulate, moderator actions are logged to an audit trail, and the reporter and uploader each get notified when a report is resolved. Admin routes now also go through shared error-handling middleware.

--- a/src/content/i-shipped/a-scoped-click-outside-attachment-replacing-the-leaky-global-window-handler.mdx
+++ b/src/content/i-shipped/a-scoped-click-outside-attachment-replacing-the-leaky-global-window-handler.mdx
@@ -1,0 +1,7 @@
+---
+summary: a scoped click-outside attachment replacing the leaky global window handler
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '65'
+---
+Brightblur's dropdown menus were using a single global `window` click listener to detect outside clicks, which fired for every click anywhere on the page. I replaced it with a scoped `clickOutside` Svelte action that attaches only to the element it needs to watch, and added Escape key support to dismiss the desktop and mobile account menus too.

--- a/src/content/i-shipped/accessibility-fixes-for-route-change-focus-dialog-traps-and-non-colour-unread-state.mdx
+++ b/src/content/i-shipped/accessibility-fixes-for-route-change-focus-dialog-traps-and-non-colour-unread-state.mdx
@@ -1,0 +1,7 @@
+---
+summary: accessibility fixes for route-change focus, dialog traps, and non-colour unread state
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '47'
+---
+I fixed four accessibility issues in brightblur: page navigation now moves keyboard focus to the main content area (with a polite announcement for screen readers), dialogs trap focus so you can't accidentally tab out, there's a skip-to-content link, and unread notifications are indicated visually beyond just colour.

--- a/src/content/i-shipped/an-end-to-end-ci-harness-gating-the-starters-release.mdx
+++ b/src/content/i-shipped/an-end-to-end-ci-harness-gating-the-starters-release.mdx
@@ -1,0 +1,7 @@
+---
+summary: an end-to-end CI harness gating the starters release
+repo: garden-co/jazz
+mergeDate: 2026-06-02
+prNumber: '978'
+---
+I added a full end-to-end testing harness for Jazz's starter templates — the scaffolded projects a new user creates with `create-jazz`. The CI now actually builds each starter and runs Playwright browser tests against it before any release goes out, so a broken starter template can no longer silently ship to users.

--- a/src/content/i-shipped/an-offline-navigation-shell-with-logout-state-purge.mdx
+++ b/src/content/i-shipped/an-offline-navigation-shell-with-logout-state-purge.mdx
@@ -1,0 +1,7 @@
+---
+summary: an offline navigation shell with logout state purge
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '84'
+---
+I added an offline navigation shell to brightblur so the app loads from a cached shell when there's no internet connection, rather than showing a browser error page. I also made logout purge all per-user data from local storage so a subsequent login on the same device doesn't see a previous user's cached state.

--- a/src/content/i-shipped/cached-feed-rendering-in-the-offline-shell.mdx
+++ b/src/content/i-shipped/cached-feed-rendering-in-the-offline-shell.mdx
@@ -1,0 +1,7 @@
+---
+summary: cached feed rendering in the offline shell
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '85'
+---
+After adding the offline shell, I extended it so a cold reload while offline shows the user's last saved feed instead of a blank shell. The service worker still only intercepts navigation failures — it doesn't redirect or cache navigation documents, so the online behaviour is completely unchanged.

--- a/src/content/i-shipped/centralised-face-thresholds-and-a-hardened-recognition-pipeline.mdx
+++ b/src/content/i-shipped/centralised-face-thresholds-and-a-hardened-recognition-pipeline.mdx
@@ -1,0 +1,7 @@
+---
+summary: centralised face thresholds and a hardened recognition pipeline
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '57'
+---
+I pulled brightblur's face-matching thresholds into a single source of truth so they can't drift apart across different code paths, fixed the LSH index re-insert so it fully replaces bucket membership instead of leaving stale entries, and replaced a recursive union-find with an iterative one to avoid stack overflows on deep ancestry chains.

--- a/src/content/i-shipped/cleanup-of-merge-operations-rows-on-group-deletion.mdx
+++ b/src/content/i-shipped/cleanup-of-merge-operations-rows-on-group-deletion.mdx
@@ -1,0 +1,7 @@
+---
+summary: cleanup of merge_operations rows on group deletion
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '66'
+---
+When a person group is deleted in brightblur, the face-merge history rows that referenced it were being left behind as orphans in the database. I updated the `deletePerson` function to also sweep those rows so the merge history stays clean.

--- a/src/content/i-shipped/client-side-upload-validation-and-face-detection-re-entrancy-guard.mdx
+++ b/src/content/i-shipped/client-side-upload-validation-and-face-detection-re-entrancy-guard.mdx
@@ -1,0 +1,7 @@
+---
+summary: client-side upload validation and face-detection re-entrancy guard
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '58'
+---
+I added file-type, extension, and size validation (20 MB cap) on the client before a photo upload even starts, so bad files are rejected immediately with a clear message. I also added a guard to prevent the face-detection pipeline from running twice simultaneously on the same photo.

--- a/src/content/i-shipped/crypto-key-rotation-validation-and-decrypt-error-surfacing.mdx
+++ b/src/content/i-shipped/crypto-key-rotation-validation-and-decrypt-error-surfacing.mdx
@@ -1,0 +1,7 @@
+---
+summary: crypto-key rotation validation and decrypt error surfacing
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '46'
+---
+I hardened three areas of brightblur's end-to-end encryption: key rotation now validates the new key before writing anything (so bad input can't brick an account), decryption errors are surfaced to the user instead of silently failing, and the app now asks whether to stay in a shared group when a key rotation happens.

--- a/src/content/i-shipped/docs-pages-for-reporting-notifications-and-account-deletion.mdx
+++ b/src/content/i-shipped/docs-pages-for-reporting-notifications-and-account-deletion.mdx
@@ -1,0 +1,7 @@
+---
+summary: docs pages for reporting, notifications, and account deletion
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '71'
+---
+I added three new pages to brightblur's docs site: one covering the content reporting and safeguarding process, one explaining push notifications, and one covering account deletion and data rights — all linked from the sidebar navigation.

--- a/src/content/i-shipped/e2e-test-updates-and-feed-delete-failure-coverage.mdx
+++ b/src/content/i-shipped/e2e-test-updates-and-feed-delete-failure-coverage.mdx
@@ -1,0 +1,7 @@
+---
+summary: e2e test updates and feed-delete failure coverage
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '54'
+---
+I updated the groups-explainer end-to-end test that had gone stale after a UI change removed the People/Circles toggle it was testing, and added new test coverage for the case where deleting a post from the feed fails.

--- a/src/content/i-shipped/eight-p2-ux-feedback-fixes-surfacing-failures-and-fixing-dead-ends.mdx
+++ b/src/content/i-shipped/eight-p2-ux-feedback-fixes-surfacing-failures-and-fixing-dead-ends.mdx
@@ -1,0 +1,7 @@
+---
+summary: eight P2 UX feedback fixes surfacing failures and fixing dead-ends
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '52'
+---
+I worked through eight UX feedback issues in brightblur: failures that were previously swallowed silently now surface to the user, loading states are consistent, action labels use the right verbs, and several dead-end flows now have a clear next step.

--- a/src/content/i-shipped/end-to-end-encrypted-photo-captions-with-editing.mdx
+++ b/src/content/i-shipped/end-to-end-encrypted-photo-captions-with-editing.mdx
@@ -1,0 +1,7 @@
+---
+summary: end-to-end encrypted photo captions with editing
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '83'
+---
+Photo captions in brightblur were stored as plain text, while photo content itself was end-to-end encrypted. I switched captions to be encrypted with the same content key as the photo, and re-added the caption edit affordance that had been removed. Both single-photo and batch-upload paths now encrypt captions.

--- a/src/content/i-shipped/hardened-encrypted-blob-storage-with-fixed-content-type-and-per-part-size-cap.mdx
+++ b/src/content/i-shipped/hardened-encrypted-blob-storage-with-fixed-content-type-and-per-part-size-cap.mdx
@@ -1,0 +1,7 @@
+---
+summary: hardened encrypted-blob storage with fixed content-type and per-part size cap
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '60'
+---
+I hardened brightblur's encrypted photo storage in two ways: encrypted blobs are now always stored with `application/octet-stream` instead of whatever content-type the browser guessed, and individual blob parts are now rejected early if they exceed a size cap before being assembled.

--- a/src/content/i-shipped/hardened-scheduled-handler-injection-wasm-caching-and-ci-lint-gating.mdx
+++ b/src/content/i-shipped/hardened-scheduled-handler-injection-wasm-caching-and-ci-lint-gating.mdx
@@ -1,0 +1,7 @@
+---
+summary: hardened scheduled-handler injection, WASM caching, and CI lint gating
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '69'
+---
+I hardened three infrastructure areas: the scheduled-task handler injection now resolves robustly and fails at build time with a clear error if the expected reference is missing; the service worker now caches whichever WASM binary variant the device loads (using a prefix match); and lint runs in CI so style issues are caught automatically.

--- a/src/content/i-shipped/paginated-comment-loading-with-incremental-decryption.mdx
+++ b/src/content/i-shipped/paginated-comment-loading-with-incremental-decryption.mdx
@@ -1,0 +1,7 @@
+---
+summary: paginated comment loading with incremental decryption
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '61'
+---
+I added keyset pagination to brightblur's comment API so long threads load in pages rather than all at once, and changed the client to decrypt only newly loaded comments instead of re-decrypting the whole thread every time. A database index migration makes the cursor-based pagination fast.

--- a/src/content/i-shipped/pagination-for-loading-earlier-comments.mdx
+++ b/src/content/i-shipped/pagination-for-loading-earlier-comments.mdx
@@ -1,0 +1,7 @@
+---
+summary: pagination for loading earlier comments
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '82'
+---
+The comment API had been updated to support pagination, but the client was only ever fetching the first page and silently dropping the rest. I wired the cursor through so long threads show a "Load more comments" button, and kept the next-page cursor around to fetch subsequent pages.

--- a/src/content/i-shipped/passkey-credential-management-with-list-rename-and-revoke.mdx
+++ b/src/content/i-shipped/passkey-credential-management-with-list-rename-and-revoke.mdx
@@ -1,0 +1,7 @@
+---
+summary: passkey credential management with list, rename, and revoke
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '45'
+---
+I built the passkey management UI for brightblur's Settings page so users can see all their registered passkeys, give them friendly names, and revoke ones they no longer use. Previously users could register passkeys but had no way to manage them afterwards.

--- a/src/content/i-shipped/post-review-cleanup-of-p3-nits.mdx
+++ b/src/content/i-shipped/post-review-cleanup-of-p3-nits.mdx
@@ -1,0 +1,7 @@
+---
+summary: post-review cleanup of P3 nits
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '81'
+---
+I cleared the non-blocking review comments left from the P3 bug sweep: the search debounce timer is now cancelled on component unmount, a stale in-flight comment decryption is cancelled when new ones start, and several clarity and correctness nits across search, comments, and the face recognition libraries were tidied up.

--- a/src/content/i-shipped/profile-editing-and-a-gdpr-data-export-endpoint.mdx
+++ b/src/content/i-shipped/profile-editing-and-a-gdpr-data-export-endpoint.mdx
@@ -1,0 +1,7 @@
+---
+summary: profile editing and a GDPR data-export endpoint
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '68'
+---
+I added profile editing to brightblur's Settings page so users can update their first name, last name, and email. I also built a data-export endpoint that packages up a user's profile, photo metadata, group memberships, and comments as a downloadable JSON archive — surfaced from the same Settings page.

--- a/src/content/i-shipped/rate-limiting-for-csp-reports-and-the-reporting-endpoints-header.mdx
+++ b/src/content/i-shipped/rate-limiting-for-csp-reports-and-the-reporting-endpoints-header.mdx
@@ -1,0 +1,7 @@
+---
+summary: rate-limiting for CSP reports and the Reporting-Endpoints header
+repo: joeinnes/brightblur
+mergeDate: 2026-06-03
+prNumber: '64'
+---
+I added a per-IP rate limit to the CSP report endpoint (Content Security Policy is a browser security feature that reports policy violations back to the server) so it can't be flooded, and added the modern `Reporting-Endpoints` header alongside the older `Report-To` header for broader browser compatibility.

--- a/src/content/i-shipped/security-and-auth-hardening-with-five-p2-fixes.mdx
+++ b/src/content/i-shipped/security-and-auth-hardening-with-five-p2-fixes.mdx
@@ -1,0 +1,7 @@
+---
+summary: security and auth hardening with five P2 fixes
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '44'
+---
+I added hardening headers (like X-Frame-Options and HSTS) to the error responses that were previously bypassing brightblur's security middleware, and fixed four other auth/security issues. These were edge-case responses — like rate-limit rejections — that were missing the protective headers the rest of the app already had.

--- a/src/content/i-shipped/seven-p2-data-integrity-and-face-recognition-bug-fixes.mdx
+++ b/src/content/i-shipped/seven-p2-data-integrity-and-face-recognition-bug-fixes.mdx
@@ -1,0 +1,7 @@
+---
+summary: seven P2 data-integrity and face-recognition bug fixes
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '42'
+---
+I fixed seven data-integrity and face-recognition bugs in brightblur. The most impactful was adding a database index to the face-slice rejection path, which was previously doing expensive full-table scans on an unbounded table every time a duplicate face was detected.

--- a/src/content/i-shipped/terms-of-service-and-accessibility-statement-pages.mdx
+++ b/src/content/i-shipped/terms-of-service-and-accessibility-statement-pages.mdx
@@ -1,0 +1,7 @@
+---
+summary: Terms of Service and Accessibility Statement pages
+repo: joeinnes/brightblur
+mergeDate: 2026-06-02
+prNumber: '48'
+---
+I added the two missing legal documents to brightblur's docs site — a Terms of Service and an Accessibility Statement — single-sourced the same way as the existing Privacy Policy, so they all live in one place and render consistently.

--- a/src/content/i-shipped/type-checking-for-docs-example-snippets-in-the-build.mdx
+++ b/src/content/i-shipped/type-checking-for-docs-example-snippets-in-the-build.mdx
@@ -1,0 +1,7 @@
+---
+summary: type-checking for docs example snippets in the build
+repo: garden-co/jazz
+mergeDate: 2026-06-02
+prNumber: '979'
+---
+I wired up type-checking for all the code examples embedded in Jazz's documentation — TypeScript, Svelte, and Vue variants. Before this, a snippet could have a type error and nobody would notice until a user tried to copy it. Now a broken snippet fails the build, so the docs always reflect working code.


### PR DESCRIPTION
Adds 38 new i-shipped entries covering merged PRs from 2026-06-02 to 2026-06-04.

- **garden-co/jazz**: PRs #978 and #979 (e2e CI harness for starters, type-checking docs snippets)
- **joeinnes/bearli**: PR #1 (47-ticket backlog sweep)
- **joeinnes/brightblur**: PRs #42–#86, 35 entries (data-integrity fixes, security hardening, passkey management, accessibility, offline support, E2E encrypted captions, face recognition hardening, and more)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kg2z2at1NWcjrd1ZD9eyRZ)_