### PR TITLE
chore(i-shipped): remove duplicate entries for jazz PRs 978 and 979

### DIFF
--- a/src/content/i-shipped/an-end-to-end-test-harness-for-jazz-starter-templates.mdx
+++ b/src/content/i-shipped/an-end-to-end-test-harness-for-jazz-starter-templates.mdx
@@ -1,7 +1,0 @@
----
-summary: an end-to-end test harness for Jazz starter templates
-repo: garden-co/jazz
-mergeDate: 2026-06-02
-prNumber: '978'
----
-Individual starter tests ran against dev builds and missed regressions that only showed up at release time. I built a new testing package that scaffolds each of the 12 starters using the real CLI, installs dependencies, builds for production, and runs all Playwright tests against the production build — all gated in CI before any release goes out.

--- a/src/content/i-shipped/type-checking-for-docs-example-snippets-in-the-build-pipeline.mdx
+++ b/src/content/i-shipped/type-checking-for-docs-example-snippets-in-the-build-pipeline.mdx
@@ -1,7 +1,0 @@
----
-summary: type-checking for docs example snippets in the build pipeline
-repo: garden-co/jazz
-mergeDate: 2026-06-02
-prNumber: '979'
----
-Broken code examples in the Jazz docs were shipping silently because they weren't type-checked. I wired TypeScript checking for all six docs example packages into the build pipeline, which also surfaced a bunch of existing errors in the snippets — wrong function signatures, renamed components, non-existent columns — that I fixed at the same time.


### PR DESCRIPTION
No new merged PRs were found to add — all recent PRs by joeinnes were already covered by existing entries.

While auditing, I found that two PRs had been added twice under slightly different filenames:
- `garden-co/jazz` #978: `an-end-to-end-test-harness-for-jazz-starter-templates.mdx` (duplicate of `an-end-to-end-ci-harness-gating-the-starters-release.mdx`)
- `garden-co/jazz` #979: `type-checking-for-docs-example-snippets-in-the-build-pipeline.mdx` (duplicate of `type-checking-for-docs-example-snippets-in-the-build.mdx`)

This PR removes the redundant copies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN558pwA5Gmowdd9i8ztg8)_