### PR TITLE
add i-shipped entry for joeinnes/plane-spotter #2

### DIFF
--- a/src/content/i-shipped/a-batch-of-bug-fixes-and-ui-improvements-to-my-plane-spotting-app.mdx
+++ b/src/content/i-shipped/a-batch-of-bug-fixes-and-ui-improvements-to-my-plane-spotting-app.mdx
@@ -1,0 +1,7 @@
+---
+summary: a batch of bug fixes and UI improvements to my plane-spotting app
+repo: joeinnes/plane-spotter
+mergeDate: 2026-02-18
+prNumber: '2'
+---
+I built a web app that shows nearby aircraft in real time using your device's location and compass. Several bugs had crept in: the direction logic for eastward-flying planes was wrong (I had `||` where I needed `&&`), the app sat empty for 2.5 seconds waiting for its first data fetch, and the device compass only worked in Safari. I fixed all of these and polished the UI — adding a sky gradient, a status bar showing how many planes are in view, readable text shadows on flight labels, and a message when no aircraft are visible.


### PR DESCRIPTION
Adds the one missing i-shipped entry found after a full audit of merged PRs by joeinnes since November 2025.

**New entry:** `joeinnes/plane-spotter #2` (merged 2026-02-18) — a batch of bug fixes and UI improvements to the plane-spotting app.

All other PRs from the search (garden-co/jazz, joeinnes/brightblur, joeinnes/bearli, garden-co/classic-jazz, sveltejs/language-tools, vercel/workflow, mksglu/context-mode, ueberdosis/tiptap-docs, joeinnes/alphaTabSamplesWeb, joeinnes/chicken-dinner-timer) were already covered by existing entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RydTZdp5KAQ58sjzDdteV4)_