### PR TITLE
feat(i-shipped): add 2 new jazz entries from 2026-06-18

### DIFF
--- a/src/content/i-shipped/a-fix-for-a-sharedworker-crash-in-production-bundler-builds.mdx
+++ b/src/content/i-shipped/a-fix-for-a-sharedworker-crash-in-production-bundler-builds.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for a SharedWorker crash in production bundler builds
+repo: garden-co/jazz
+mergeDate: 2026-06-18
+prNumber: '1030'
+---
+Jazz apps use a SharedWorker — a background browser thread — to coordinate data between tabs. The worker file was shipped with references to other files using bare paths, but bundlers like Webpack, Turbopack, and Vite in production mode couldn't recognise it as a worker entry, so they copied it verbatim and those references would 404, crashing every Jazz app with "Browser broker SharedWorker failed to start." I fixed this by bundling the worker into a single self-contained file at build time, so it works correctly regardless of which bundler the app uses.

--- a/src/content/i-shipped/a-new-jazz-toolsshared-entry-point-for-building-custom-framework-bindings.mdx
+++ b/src/content/i-shipped/a-new-jazz-toolsshared-entry-point-for-building-custom-framework-bindings.mdx
@@ -1,0 +1,8 @@
+---
+summary: >-
+  a new `jazz-tools/shared` entry point for building custom framework bindings
+repo: garden-co/jazz
+mergeDate: 2026-06-18
+prNumber: '1029'
+---
+Jazz has bindings for React, Svelte, and Vue, but if you wanted to build a binding for another framework, you'd have to dig into the package's internals. I added a new `jazz-tools/shared` entry point that exposes the core utilities — the helpers that turn a live query into a reactive, in-place-updated result — so external developers can build custom bindings without touching anything private. The React, Svelte, and Vue bindings were also updated to import from this new public surface instead of deep internal paths.


### PR DESCRIPTION
Adds 2 new i-shipped entries for merged PRs in garden-co/jazz on 2026-06-18:

- **#1029**: Expose `jazz-tools/shared` entry point — new public surface for building custom framework bindings without touching package internals
- **#1030**: Fix SharedWorker crash in production bundler builds — bundles the broker worker into self-contained ESM so bare imports don't 404

---
_Generated by [Claude Code](https://claude.ai/code/session_0115i2GZToawuXATFXGt4Qnh)_