### PR TITLE
perf: remove duplicate render-blocking font load, fix preconnect, defer NowPlaying

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -69,6 +69,7 @@ const imageUrl = new URL(image, Astro.site).href;
 <meta name="generator" content={Astro.generator} />
 
 <link rel="preconnect" href="https://fonts.bunny.net" />
+<link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
 <link
   href="https://fonts.bunny.net/css?family=space-grotesk:400,700|space-mono:400,700&display=swap"
   rel="stylesheet"

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -37,7 +37,7 @@ const { title, bg, description, image, type } = Astro.props;
     <div id="main-content" tabindex="-1">
       <slot />
     </div>
-    <NowPlaying client:load />
+    <NowPlaying client:idle />
     <style>
       .skip-link {
         position: absolute;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,3 @@
-@import url(https://fonts.bunny.net/css?family=space-mono:400,700);
 @layer reset, base, utilities, components, layout;
 
 @layer reset {


### PR DESCRIPTION
Front-end performance quick-wins to cut page load time (current Web Analytics median ~4.6s).

## Changes

- **Remove the duplicate, render-blocking font `@import`** (`src/styles.css`). It loaded Space Mono via a remote `@import` inside the bundled CSS — a chained request discovered only after `styles.css` parsed, and with no `display=swap` (causing flash-of-invisible-text). Space Mono is already loaded via the `BaseHead` `<link>` with `display=swap`, so this removes a redundant font request from the critical path.
- **Add a `crossorigin` preconnect** to `fonts.bunny.net` (`src/components/BaseHead.astro`). Font-file fetches are CORS/anonymous and use a separate connection from the stylesheet fetch; warming it avoids an extra DNS/TLS round-trip before text renders.
- **Defer `NowPlaying` from `client:load` to `client:idle`** (`src/layouts/Default.astro`). The widget's Svelte runtime and its `bsky.social` fetch no longer compete for the main thread during initial load. It's a non-essential floating widget — no UX change.

## Verification

- `pnpm build` completes successfully.
- Built `dist/client/index.html` contains both preconnects (plain + crossorigin) and the `display=swap` font `<link>`.
- No leftover `space-mono` `@import` remains in the built CSS.

## Notes / follow-ups

- Truly self-hosting the four woff2 files (with `preload`) is the biggest remaining win but couldn't be done in the session environment (network policy blocks `fonts.bunny.net`). Worth a follow-up.
- Several multi-MB images in `public/` (a 13MB PNG, a 10MB `bread.png`, several 2–3MB JPEGs) inflate load on blog/widget pages and should be compressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBGGyhhweJL8957nGHwK6e)_