### PR TITLE
fix: strip mbid: prefix so now-playing cover art loads

### DIFF
--- a/src/components/NowPlaying.svelte
+++ b/src/components/NowPlaying.svelte
@@ -41,6 +41,20 @@
 		}
 	});
 
+	// teal.fm stores MBIDs prefixed, e.g. "mbid:0fc05d92-255c-...". Cover Art
+	// Archive wants the bare UUID; the prefixed value yields a 400 "invalid MBID
+	// specified" page that also trips OpaqueResponseBlocking. Strip and validate.
+	const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	function cleanMbid(raw) {
+		if (typeof raw !== 'string') return null;
+		const id = raw.replace(/^mbid:/i, '').trim();
+		return MBID_RE.test(id) ? id : null;
+	}
+	function coverUrl(raw) {
+		const id = cleanMbid(raw);
+		return id ? `${COVER_ART_BASE}/${id}/front-250` : null;
+	}
+
 	function artistNames(t) {
 		if (t.artists?.length) return t.artists.map((a) => a.artistName).join(', ');
 		if (t.artistNames?.length) return t.artistNames.join(', ');
@@ -55,9 +69,9 @@
 {#if show && track}
 	<a href="/now" class="now-playing">
 		<div class="np-cover">
-			{#if track.releaseMbId}
+			{#if coverUrl(track.releaseMbId)}
 				<img
-					src="{COVER_ART_BASE}/{track.releaseMbId}/front-250"
+					src={coverUrl(track.releaseMbId)}
 					alt={track.releaseName || track.trackName}
 					onerror={handleImgError}
 				/>

--- a/src/components/RecentTracks.svelte
+++ b/src/components/RecentTracks.svelte
@@ -223,9 +223,20 @@
 		return 'Unknown Artist';
 	}
 
+	// teal.fm stores MBIDs prefixed, e.g. "mbid:0fc05d92-255c-4a91-b3ed-...".
+	// Cover Art Archive wants the bare UUID; passing the prefixed value yields a
+	// 400 "invalid MBID specified" HTML page, which also trips Firefox's
+	// OpaqueResponseBlocking. Strip the prefix and validate the UUID shape.
+	const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	function cleanMbid(raw) {
+		if (typeof raw !== 'string') return null;
+		const id = raw.replace(/^mbid:/i, '').trim();
+		return MBID_RE.test(id) ? id : null;
+	}
+
 	function coverUrl(releaseMbId) {
-		if (!releaseMbId) return null;
-		return `${COVER_ART_BASE}/${releaseMbId}/front-250`;
+		const id = cleanMbid(releaseMbId);
+		return id ? `${COVER_ART_BASE}/${id}/front-250` : null;
 	}
 
 	function filterByPeriod(tracks, period) {
@@ -329,7 +340,7 @@
 			{#each recentTracks as track}
 				<li class="recent-track">
 					<div class="recent-cover">
-						{#if track.releaseMbId}
+						{#if coverUrl(track.releaseMbId)}
 							<img
 								src={coverUrl(track.releaseMbId)}
 								alt={track.releaseName || track.trackName}
@@ -359,7 +370,7 @@
 		<div class="mosaic">
 			{#each weeklyAlbums as album}
 				<div class="mosaic-cell" title="{album.name} — {album.artist}">
-					{#if album.mbId}
+					{#if coverUrl(album.mbId)}
 						<img
 							src={coverUrl(album.mbId)}
 							alt="{album.name} by {album.artist}"
@@ -404,7 +415,7 @@
 			{#each stats as item}
 				<li class="stat-item">
 					<div class="stat-cover">
-						{#if item.mbId}
+						{#if coverUrl(item.mbId)}
 							<img
 								src={coverUrl(item.mbId)}
 								alt={item.name}


### PR DESCRIPTION
## Problem
No cover art was loading on the Now page / now-playing widget. Every request failed with a 400 `invalid MBID specified` HTML page from Cover Art Archive, which in turn tripped Firefox's OpaqueResponseBlocking.

## Cause
teal.fm stores release MBIDs **prefixed**, e.g. `mbid:0fc05d92-255c-4a91-b3ed-de6b63210ca1`. The components passed that raw value straight into `coverartarchive.org/release/{mbid}/front-250`, so the archive received `mbid:0fc05d92…` (not a bare UUID) and rejected every request.

## Fix
- Add a `cleanMbid()` helper that strips a leading `mbid:` prefix and validates the UUID shape.
- Build the cover URL from the cleaned id, and only render the `<img>` when a valid id is present (otherwise the existing fallback shows).
- Applied in both `NowPlaying.svelte` and `RecentTracks.svelte`.

## Verification
- `pnpm build` passes.
- Unit-checked the normalisation: `mbid:<uuid>` → bare UUID; bare UUIDs pass through unchanged; malformed/empty/null → `null` (graceful fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBGGyhhweJL8957nGHwK6e)_