### PR TITLE
Now page: BookHive currently-reading + Right Now snapshot; card copy

### DIFF
--- a/src/components/CurrentlyReading.svelte
+++ b/src/components/CurrentlyReading.svelte
@@ -1,0 +1,139 @@
+<script>
+	import { onMount } from 'svelte';
+
+	const HANDLE = 'joeinn.es';
+	const COLLECTION = 'buzz.bookhive.book';
+	const PDS = 'https://bsky.social';
+	const READING = 'buzz.bookhive.defs#reading';
+
+	let books = $state([]);
+
+	// Records are returned as at://did:plc:.../buzz.bookhive.book/<rkey>;
+	// the DID is needed to fetch the cover blob.
+	function didFromUri(uri) {
+		const m = /^at:\/\/(did:[^/]+)\//.exec(uri ?? '');
+		return m ? m[1] : null;
+	}
+
+	// The cover is a blob on the record; resolve it via getBlob on the PDS.
+	function coverUrl(did, cover) {
+		const cid = cover?.ref?.$link;
+		if (!did || !cid) return null;
+		return `${PDS}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${encodeURIComponent(cid)}`;
+	}
+
+	// authors is a single tab-separated string in the lexicon
+	function authorList(authors) {
+		if (typeof authors !== 'string') return '';
+		return authors.split('\t').filter(Boolean).join(', ');
+	}
+
+	onMount(async () => {
+		try {
+			const params = new URLSearchParams({
+				repo: HANDLE,
+				collection: COLLECTION,
+				limit: '100',
+			});
+			const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
+			if (!res.ok) return;
+			const data = await res.json();
+			books = (data.records ?? [])
+				.filter((r) => r.value?.status === READING)
+				.map((r) => {
+					const did = didFromUri(r.uri);
+					return {
+						title: r.value.title ?? 'Untitled',
+						authors: authorList(r.value.authors),
+						cover: coverUrl(did, r.value.cover),
+					};
+				});
+		} catch {
+			// Nice-to-have; fail silently.
+		}
+	});
+
+	function handleImgError(e) {
+		e.currentTarget.style.display = 'none';
+	}
+</script>
+
+{#if books.length > 0}
+	<h2>Reading...</h2>
+	<ul class="reading-grid">
+		{#each books as book}
+			<li class="book">
+				<div class="book-cover">
+					{#if book.cover}
+						<img src={book.cover} alt={book.title} loading="lazy" onerror={handleImgError} />
+					{/if}
+					<div class="book-cover-fallback">{book.title[0] ?? '?'}</div>
+				</div>
+				<div class="book-info">
+					<span class="name">{book.title}</span>
+					{#if book.authors}
+						<span class="author">{book.authors}</span>
+					{/if}
+				</div>
+			</li>
+		{/each}
+	</ul>
+{/if}
+
+<style>
+	.reading-grid {
+		list-style: none;
+		padding: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+		gap: calc(var(--inline-spacing) * 4);
+	}
+	.reading-grid * {
+		padding-block-start: 0;
+	}
+	.book {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--inline-spacing) * 2);
+	}
+	.book-cover {
+		position: relative;
+		aspect-ratio: 2 / 3;
+		border-radius: var(--border-radius);
+		overflow: hidden;
+		background: color-mix(in hsl, var(--foreground) 10%, var(--background) 90%);
+		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+	}
+	.book-cover img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		z-index: 1;
+	}
+	.book-cover-fallback {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 700;
+		font-size: 1.5em;
+		color: var(--muted);
+	}
+	.book-info {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+	.name {
+		font-weight: 700;
+		font-size: 0.85em;
+		line-height: 1.2;
+	}
+	.author {
+		color: var(--muted);
+		font-size: 0.75em;
+	}
+</style>

--- a/src/components/RightNow.svelte
+++ b/src/components/RightNow.svelte
@@ -1,0 +1,205 @@
+<script>
+	import { onMount } from 'svelte';
+
+	const HANDLE = 'joeinn.es';
+	const PDS = 'https://bsky.social';
+	const PLAY_COLLECTION = 'fm.teal.alpha.feed.play';
+	const BOOK_COLLECTION = 'buzz.bookhive.book';
+	const READING = 'buzz.bookhive.defs#reading';
+	const COVER_ART_BASE = 'https://coverartarchive.org/release';
+
+	let track = $state(null);
+	let book = $state(null);
+
+	// --- music cover: MusicBrainz id (prefixed "mbid:") via Cover Art Archive ---
+	const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	function trackCover(raw) {
+		if (typeof raw !== 'string') return null;
+		const id = raw.replace(/^mbid:/i, '').trim();
+		return MBID_RE.test(id) ? `${COVER_ART_BASE}/${id}/front-250` : null;
+	}
+	function artistNames(t) {
+		if (t?.artists?.length) return t.artists.map((a) => a.artistName).join(', ');
+		if (t?.artistNames?.length) return t.artistNames.join(', ');
+		return '';
+	}
+
+	// --- book cover: blob resolved via getBlob (DID parsed from the record uri) ---
+	function bookCover(uri, cover) {
+		const did = /^at:\/\/(did:[^/]+)\//.exec(uri ?? '')?.[1];
+		const cid = cover?.ref?.$link;
+		if (!did || !cid) return null;
+		return `${PDS}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${encodeURIComponent(cid)}`;
+	}
+	function authorList(a) {
+		return typeof a === 'string' ? a.split('\t').filter(Boolean).join(', ') : '';
+	}
+
+	async function fetchLatestTrack() {
+		const params = new URLSearchParams({ repo: HANDLE, collection: PLAY_COLLECTION, limit: '1' });
+		const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
+		if (!res.ok) return;
+		const r = (await res.json()).records?.[0];
+		if (!r) return;
+		track = {
+			name: r.value.trackName,
+			artist: artistNames(r.value),
+			cover: trackCover(r.value.releaseMbId),
+		};
+	}
+
+	async function fetchCurrentBook() {
+		const params = new URLSearchParams({ repo: HANDLE, collection: BOOK_COLLECTION, limit: '100' });
+		const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
+		if (!res.ok) return;
+		const r = ((await res.json()).records ?? []).find((x) => x.value?.status === READING);
+		if (!r) return;
+		book = {
+			title: r.value.title ?? 'Untitled',
+			author: authorList(r.value.authors),
+			cover: bookCover(r.uri, r.value.cover),
+		};
+	}
+
+	onMount(() => {
+		fetchLatestTrack().catch(() => {});
+		fetchCurrentBook().catch(() => {});
+	});
+
+	function hideImg(e) {
+		e.currentTarget.style.display = 'none';
+	}
+</script>
+
+{#if track || book}
+	<div class="right-now">
+		<span class="rn-eyebrow">Right now</span>
+		<div class="rn-items">
+			{#if book}
+				<div class="rn-item">
+					<div class="rn-cover book">
+						{#if book.cover}
+							<img src={book.cover} alt={book.title} loading="lazy" onerror={hideImg} />
+						{/if}
+						<span class="rn-cover-fallback">{book.title[0] ?? '?'}</span>
+					</div>
+					<div class="rn-info">
+						<span class="rn-label">Reading</span>
+						<span class="rn-title">{book.title}</span>
+						{#if book.author}<span class="rn-sub">{book.author}</span>{/if}
+					</div>
+				</div>
+			{/if}
+
+			{#if track}
+				<div class="rn-item">
+					<div class="rn-cover track">
+						{#if track.cover}
+							<img src={track.cover} alt={track.name} loading="lazy" onerror={hideImg} />
+						{/if}
+						<span class="rn-cover-fallback">&#9835;</span>
+					</div>
+					<div class="rn-info">
+						<span class="rn-label">Listening</span>
+						<span class="rn-title">{track.name}</span>
+						{#if track.artist}<span class="rn-sub">{track.artist}</span>{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.right-now {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--inline-spacing) * 3);
+		padding: calc(var(--inline-spacing) * 4);
+		border-radius: var(--border-radius);
+		border: 1px solid var(--very-muted);
+		background: color-mix(in hsl, var(--primary) 4%, var(--background) 96%);
+	}
+	.right-now * {
+		padding-block-start: 0;
+	}
+	.rn-eyebrow {
+		font-family: var(--font-mono);
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+		color: var(--muted);
+	}
+	.rn-items {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--layout-spacing);
+	}
+	.rn-item {
+		display: flex;
+		align-items: center;
+		gap: calc(var(--inline-spacing) * 3);
+		flex: 1 1 14rem;
+		min-width: 0;
+	}
+	.rn-cover {
+		position: relative;
+		flex-shrink: 0;
+		border-radius: calc(var(--border-radius) / 1.5);
+		overflow: hidden;
+		background: color-mix(in hsl, var(--foreground) 10%, var(--background) 90%);
+		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+	}
+	.rn-cover.book {
+		width: 3.25em;
+		aspect-ratio: 2 / 3;
+	}
+	.rn-cover.track {
+		width: 3.75em;
+		aspect-ratio: 1;
+	}
+	.rn-cover img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		z-index: 1;
+	}
+	.rn-cover-fallback {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 700;
+		color: var(--muted);
+	}
+	.rn-info {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+	.rn-label {
+		font-family: var(--font-mono);
+		font-size: 0.6rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--primary);
+	}
+	.rn-title {
+		font-weight: 700;
+		font-size: 0.9em;
+		line-height: 1.2;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.rn-sub {
+		color: var(--muted);
+		font-size: 0.78em;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,10 +37,10 @@ const fmtDate = (d: Date) =>
   d.toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" });
 
 const cards = [
-  { href: "/blog", label: "Blog", blurb: "Long-form writing on local-first software and the web." },
-  { href: "/i-shipped", label: "I Shipped", blurb: "A running log of merged open-source pull requests." },
+  { href: "/blog", label: "Blog", blurb: "Long-form writing. Essays, diatribes, recipes, and more." },
+  { href: "/i-shipped", label: "I Shipped", blurb: "A running log of my merged PRs." },
   { href: "/smidgeons", label: "Smidgeons", blurb: "Short notes, snippets, and passing thoughts." },
-  { href: "/now", label: "Now", blurb: "What I'm working on and listening to right now." },
+  { href: "/now", label: "Now", blurb: "What I'm working on, listening to, and reading right now." },
 ];
 ---
 

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -9,6 +9,8 @@ const now = await reader.singletons.now.read();
 const content = await now?.now();
 const renderedMd = await marked.parse(content || "");
 import RecentTracks from "../../components/RecentTracks.svelte";
+import CurrentlyReading from "../../components/CurrentlyReading.svelte";
+import RightNow from "../../components/RightNow.svelte";
 
 const description =
   "What Joe Innes is focused on right now — current projects, priorities, and recent listening.";
@@ -18,7 +20,11 @@ const description =
   <Nav />
   <main>
     <h1 class="title">Now</h1>
+    <RightNow client:load />
     <article set:html={renderedMd} />
+    <article>
+      <CurrentlyReading client:load />
+    </article>
     <article>
       <h2>Listening To...</h2>
       <RecentTracks client:load />


### PR DESCRIPTION
## Home card copy
- Blog → "Long-form writing. Essays, diatribes, recipes, and more."
- I Shipped → "A running log of my merged PRs."
- Now → "What I'm working on, listening to, and reading right now."
- Smidgeons → unchanged.

## BookHive "currently reading" (over AT Protocol)
Fetches what I'm reading using the same `com.atproto.repo.listRecords` approach as the teal.fm fetcher.

- `CurrentlyReading.svelte`: lists `buzz.bookhive.book` records where `status === "buzz.bookhive.defs#reading"` and renders every cover in a responsive grid. The cover is a blob, resolved via `com.atproto.sync.getBlob` using the DID parsed from each record's `at://…` URI; `authors` is a tab-separated string, joined for display.

## "Right now" snapshot-hero layout
- `RightNow.svelte`: a compact at-a-glance band pairing the current book with the latest play (reusing the `mbid:` prefix handling for album art).
- `now/index.astro` order is now: **snapshot → intro prose → Reading → Listening**.

## Verification
- `pnpm build` passes.
- Parse logic unit-checked: reading-only filter, tab-separated authors → "A, B", DID parsed from record URI, getBlob cover URL, null → graceful fallback.
- Now page hydrates with zero console errors; section order confirmed via CDP.
- Note: the build sandbox can't reach `bsky.social`, so live book/track data wasn't rendered here — only logic, structure, and styling were verified. Covers fall back gracefully when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBGGyhhweJL8957nGHwK6e)_