### PR TITLE
Now: two-column Right Now snapshot

### DIFF
--- a/src/components/RightNow.svelte
+++ b/src/components/RightNow.svelte
@@ -131,16 +131,33 @@
 		color: var(--muted);
 	}
 	.rn-items {
-		display: flex;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
 		gap: var(--layout-spacing);
+		align-items: center;
 	}
 	.rn-item {
 		display: flex;
 		align-items: center;
 		gap: calc(var(--inline-spacing) * 3);
-		flex: 1 1 14rem;
 		min-width: 0;
+	}
+	/* divider between the two columns */
+	.rn-item + .rn-item {
+		border-inline-start: 1px solid var(--very-muted);
+		padding-inline-start: var(--layout-spacing);
+	}
+	/* stack into one column on narrow screens, divider goes horizontal */
+	@media (max-width: 32rem) {
+		.rn-items {
+			grid-template-columns: 1fr;
+		}
+		.rn-item + .rn-item {
+			border-inline-start: none;
+			padding-inline-start: 0;
+			border-block-start: 1px solid var(--very-muted);
+			padding-block-start: var(--layout-spacing);
+		}
 	}
 	.rn-cover {
 		position: relative;


### PR DESCRIPTION
Lay the "Right now" snapshot out as two equal columns — **Reading** on the left, **Listening** on the right — separated by a divider, instead of a wrapping flex row.

- Two-column grid (`1fr 1fr`) with a vertical divider between the columns.
- Stacks to a single column with a horizontal divider on narrow screens (≤512px viewport).

## Verification
- `pnpm build` passes.
- Rendered a visual mock at desktop (two columns + divider) and mobile (stacked) to confirm the layout and graceful truncation of long titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBGGyhhweJL8957nGHwK6e)_