### PR TITLE
fix: restore updated home card copy (reverted by #50)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,10 +38,10 @@ const fmtDate = (d: Date) =>
   d.toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric" });
 
 const cards = [
-  { href: "/blog", label: "Blog", blurb: "Long-form writing on local-first software and the web." },
-  { href: "/i-shipped", label: "I Shipped", blurb: "A running log of merged open-source pull requests." },
+  { href: "/blog", label: "Blog", blurb: "Long-form writing. Essays, diatribes, recipes, and more." },
+  { href: "/i-shipped", label: "I Shipped", blurb: "A running log of my merged PRs." },
   { href: "/smidgeons", label: "Smidgeons", blurb: "Short notes, snippets, and passing thoughts." },
-  { href: "/now", label: "Now", blurb: "What I'm working on and listening to right now." },
+  { href: "/now", label: "Now", blurb: "What I'm working on, listening to, and reading right now." },
 ];
 ---
 


### PR DESCRIPTION
## Why
The home wayfinding card copy was updated in #47, but PR #50 (live weather window backdrop) branched from before that change and reverted the Blog / I Shipped / Now blurbs back to the old text when it merged — which is why the live site still shows the old copy.

## Fix
Re-apply the intended blurbs on top of the current home page (the weather-window code from #50 is untouched):

- Blog → "Long-form writing. Essays, diatribes, recipes, and more."
- I Shipped → "A running log of my merged PRs."
- Now → "What I'm working on, listening to, and reading right now."
- Smidgeons → unchanged.

`pnpm build` passes; verified the corrected blurbs render in the built output. Net diff is three lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBGGyhhweJL8957nGHwK6e)_