### PR TITLE
feat(i-shipped): add joeinn.es-old #1 broken image fix

### DIFF
--- a/src/content/i-shipped/a-fix-for-broken-image-links-in-a-few-old-blog-posts.mdx
+++ b/src/content/i-shipped/a-fix-for-broken-image-links-in-a-few-old-blog-posts.mdx
@@ -1,0 +1,7 @@
+---
+summary: a fix for broken image links in a few old blog posts
+repo: joeinnes/joeinn.es-old
+mergeDate: 2021-11-07
+prNumber: '1'
+---
+On an earlier version of my personal site, a handful of old blog posts had photos that just wouldn't load because the links to the image files were broken. I went through the affected posts and cleaned up the markdown so the images pointed to the right place again.


### PR DESCRIPTION
## Summary
- Adds an i-shipped entry for `joeinnes/joeinn.es-old#1`, a fix for broken image links in a few old blog posts on an earlier version of the personal site.

Searched all merged PRs by `joeinnes` across public repos found via the GitHub search API; this was the only public-repo PR not yet covered (everything else newer/uncovered was in private repos like `brightblur`, `bearli`, `plane-spotter`, `danny-weight`, `ada-joe`, `agent-stats`, or already logged).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8srfynQNvjVBTGvQGX8x7)_