### PR TITLE
Hide monthly digests from the i-shipped page

### DIFF
--- a/src/pages/i-shipped/[...page].astro
+++ b/src/pages/i-shipped/[...page].astro
@@ -126,7 +126,10 @@ const groupedByDate = paginated.reduce(
 );
 
 // Latest digest (any period) — shown as an intro summary on the first page only.
-const digest = currentPage === 1 ? await loadLatestDigest() : null;
+// Hidden for now: the records stay on the PDS (es.joeinn.shippedDigest), we just
+// don't render them. Flip SHOW_DIGESTS to bring them back.
+const SHOW_DIGESTS = false;
+const digest = SHOW_DIGESTS && currentPage === 1 ? await loadLatestDigest() : null;
 const DigestContent = digest?.entry ? (await render(digest.entry)).Content : null;
 const digestHtml: string =
   digest && !digest.entry ? await marked.parse(digest.markdown ?? "") : "";


### PR DESCRIPTION
## Summary
- The i-shipped page no longer renders the latest monthly digest as an intro
  summary. The es.joeinn.shippedDigest records stay on the PDS untouched, gated
  behind a SHOW_DIGESTS flag to re-enable.

## Test plan
- [ ] `pnpm build`; /i-shipped page 1 shows no digest section, PR entries intact