### PR TITLE
Allow the Vercel deploy hook through the CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -26,7 +26,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'self'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src 'self' https://fonts.bunny.net data:; script-src 'self' 'unsafe-inline'; connect-src 'self' https://bsky.social https://public.api.bsky.app https://coverartarchive.org https://api.open-meteo.com https://api.joeinn.es https://plc.directory https://*.host.bsky.network; frame-src 'self' https://www.youtube.com https://www.openstreetmap.org; form-action 'self' https://formspree.io; upgrade-insecure-requests"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'self'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.bunny.net; font-src 'self' https://fonts.bunny.net data:; script-src 'self' 'unsafe-inline'; connect-src 'self' https://bsky.social https://public.api.bsky.app https://coverartarchive.org https://api.open-meteo.com https://api.joeinn.es https://plc.directory https://*.host.bsky.network https://api.vercel.com; frame-src 'self' https://www.youtube.com https://www.openstreetmap.org; form-action 'self' https://formspree.io; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- The publish-on-save deploy hook POSTs to api.vercel.com, which the CSP
  connect-src didn't allow — so the browser blocked the request. Adds
  https://api.vercel.com to connect-src.
- Note: also requires PUBLIC_DEPLOY_HOOK_URL to be set in the Vercel project
  environment (not just local .env) so it's inlined at build.

## Test plan
- [ ] With PUBLIC_DEPLOY_HOOK_URL set in Vercel env, create/edit a record in
      /admin and confirm a new deployment is triggered