### PR TITLE
Show only the current book on /now, with progress; add Now to nav

### DIFF
--- a/src/components/CurrentlyReading.svelte
+++ b/src/components/CurrentlyReading.svelte
@@ -1,55 +1,14 @@
 <script>
 	import { onMount } from 'svelte';
-
-	const HANDLE = 'joeinn.es';
-	const COLLECTION = 'buzz.bookhive.book';
-	const PDS = 'https://bsky.social';
-	const READING = 'buzz.bookhive.defs#reading';
+	import { fetchCurrentBook } from '../lib/now';
 
 	// Seeded from the server for an instant first paint; onMount refreshes to live.
-	let { initialBooks = [] } = $props();
-	let books = $state(initialBooks);
-
-	// Records are returned as at://did:plc:.../buzz.bookhive.book/<rkey>;
-	// the DID is needed to fetch the cover blob.
-	function didFromUri(uri) {
-		const m = /^at:\/\/(did:[^/]+)\//.exec(uri ?? '');
-		return m ? m[1] : null;
-	}
-
-	// The cover is a blob on the record; resolve it via getBlob on the PDS.
-	function coverUrl(did, cover) {
-		const cid = cover?.ref?.$link;
-		if (!did || !cid) return null;
-		return `${PDS}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${encodeURIComponent(cid)}`;
-	}
-
-	// authors is a single tab-separated string in the lexicon
-	function authorList(authors) {
-		if (typeof authors !== 'string') return '';
-		return authors.split('\t').filter(Boolean).join(', ');
-	}
+	let { initialBook = null } = $props();
+	let book = $state(initialBook);
 
 	onMount(async () => {
 		try {
-			const params = new URLSearchParams({
-				repo: HANDLE,
-				collection: COLLECTION,
-				limit: '100',
-			});
-			const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
-			if (!res.ok) return;
-			const data = await res.json();
-			books = (data.records ?? [])
-				.filter((r) => r.value?.status === READING)
-				.map((r) => {
-					const did = didFromUri(r.uri);
-					return {
-						title: r.value.title ?? 'Untitled',
-						authors: authorList(r.value.authors),
-						cover: coverUrl(did, r.value.cover),
-					};
-				});
+			book = (await fetchCurrentBook()) ?? book;
 		} catch {
 			// Nice-to-have; fail silently.
 		}
@@ -60,46 +19,45 @@
 	}
 </script>
 
-{#if books.length > 0}
+{#if book}
 	<h2>Reading...</h2>
-	<ul class="reading-grid">
-		{#each books as book}
-			<li class="book">
-				<div class="book-cover">
-					{#if book.cover}
-						<img src={book.cover} alt={book.title} loading="lazy" onerror={handleImgError} />
-					{/if}
-					<div class="book-cover-fallback">{book.title[0] ?? '?'}</div>
-				</div>
-				<div class="book-info">
-					<span class="name">{book.title}</span>
-					{#if book.authors}
-						<span class="author">{book.authors}</span>
-					{/if}
-				</div>
-			</li>
-		{/each}
-	</ul>
+	<div class="book">
+		<div class="book-cover">
+			{#if book.cover}
+				<img src={book.cover} alt={book.title} loading="lazy" onerror={handleImgError} />
+			{/if}
+			<div class="book-cover-fallback">{book.title[0] ?? '?'}</div>
+		</div>
+		<div class="book-info">
+			<span class="name">{book.title}</span>
+			{#if book.author}
+				<span class="author">{book.author}</span>
+			{/if}
+			{#if book.progress?.percent != null}
+				<progress max="100" value={book.progress.percent}></progress>
+				<span class="progress-label">
+					{book.progress.percent}%{book.progress.currentPage && book.progress.totalPages
+						? ` · p. ${book.progress.currentPage} of ${book.progress.totalPages}`
+						: ''}
+				</span>
+			{/if}
+		</div>
+	</div>
 {/if}
 
 <style>
-	.reading-grid {
-		list-style: none;
-		padding: 0;
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
-		gap: calc(var(--inline-spacing) * 4);
-	}
-	.reading-grid * {
-		padding-block-start: 0;
-	}
 	.book {
 		display: flex;
-		flex-direction: column;
-		gap: calc(var(--inline-spacing) * 2);
+		gap: calc(var(--inline-spacing) * 4);
+		align-items: flex-start;
+	}
+	.book * {
+		padding-block-start: 0;
 	}
 	.book-cover {
 		position: relative;
+		flex-shrink: 0;
+		width: 7rem;
 		aspect-ratio: 2 / 3;
 		border-radius: var(--border-radius);
 		overflow: hidden;
@@ -129,14 +87,23 @@
 	.book-info {
 		display: flex;
 		flex-direction: column;
+		gap: calc(var(--inline-spacing) * 2);
 		min-width: 0;
 	}
 	.name {
 		font-weight: 700;
-		font-size: 0.85em;
 		line-height: 1.2;
 	}
 	.author {
+		color: var(--muted);
+		font-size: 0.85em;
+	}
+	progress {
+		width: 100%;
+		max-width: 16rem;
+		accent-color: var(--primary);
+	}
+	.progress-label {
 		color: var(--muted);
 		font-size: 0.75em;
 	}

--- a/src/components/NewNav.astro
+++ b/src/components/NewNav.astro
@@ -10,6 +10,7 @@ const links: { href: string; label: string }[] = [
   { href: "/blog", label: "Blog" },
   { href: "/i-shipped", label: "I Shipped" },
   { href: "/smidgeons", label: "Smidgeons" },
+  { href: "/now", label: "Now" },
   { href: "/cv", label: "CV" },
   { href: "/contact", label: "Contact" },
 ];

--- a/src/components/RightNow.svelte
+++ b/src/components/RightNow.svelte
@@ -62,6 +62,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: calc(var(--inline-spacing) * 3);
+		margin-block-end: var(--layout-spacing);
 		padding: calc(var(--inline-spacing) * 4);
 		border-radius: var(--border-radius);
 		border: 1px solid var(--very-muted);

--- a/src/components/RightNow.svelte
+++ b/src/components/RightNow.svelte
@@ -1,71 +1,16 @@
 <script>
 	import { onMount } from 'svelte';
-
-	const HANDLE = 'joeinn.es';
-	const PDS = 'https://bsky.social';
-	const PLAY_COLLECTION = 'fm.teal.alpha.feed.play';
-	const BOOK_COLLECTION = 'buzz.bookhive.book';
-	const READING = 'buzz.bookhive.defs#reading';
-	const COVER_ART_BASE = 'https://coverartarchive.org/release';
+	import { fetchLatestTrack, fetchCurrentBook } from '../lib/now';
 
 	// Seeded from the server for an instant first paint; onMount refreshes to live.
 	let { initialTrack = null, initialBook = null } = $props();
 	let track = $state(initialTrack);
 	let book = $state(initialBook);
 
-	// --- music cover: MusicBrainz id (prefixed "mbid:") via Cover Art Archive ---
-	const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-	function trackCover(raw) {
-		if (typeof raw !== 'string') return null;
-		const id = raw.replace(/^mbid:/i, '').trim();
-		return MBID_RE.test(id) ? `${COVER_ART_BASE}/${id}/front-250` : null;
-	}
-	function artistNames(t) {
-		if (t?.artists?.length) return t.artists.map((a) => a.artistName).join(', ');
-		if (t?.artistNames?.length) return t.artistNames.join(', ');
-		return '';
-	}
-
-	// --- book cover: blob resolved via getBlob (DID parsed from the record uri) ---
-	function bookCover(uri, cover) {
-		const did = /^at:\/\/(did:[^/]+)\//.exec(uri ?? '')?.[1];
-		const cid = cover?.ref?.$link;
-		if (!did || !cid) return null;
-		return `${PDS}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${encodeURIComponent(cid)}`;
-	}
-	function authorList(a) {
-		return typeof a === 'string' ? a.split('\t').filter(Boolean).join(', ') : '';
-	}
-
-	async function fetchLatestTrack() {
-		const params = new URLSearchParams({ repo: HANDLE, collection: PLAY_COLLECTION, limit: '1' });
-		const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
-		if (!res.ok) return;
-		const r = (await res.json()).records?.[0];
-		if (!r) return;
-		track = {
-			name: r.value.trackName,
-			artist: artistNames(r.value),
-			cover: trackCover(r.value.releaseMbId),
-		};
-	}
-
-	async function fetchCurrentBook() {
-		const params = new URLSearchParams({ repo: HANDLE, collection: BOOK_COLLECTION, limit: '100' });
-		const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
-		if (!res.ok) return;
-		const r = ((await res.json()).records ?? []).find((x) => x.value?.status === READING);
-		if (!r) return;
-		book = {
-			title: r.value.title ?? 'Untitled',
-			author: authorList(r.value.authors),
-			cover: bookCover(r.uri, r.value.cover),
-		};
-	}
-
-	onMount(() => {
-		fetchLatestTrack().catch(() => {});
-		fetchCurrentBook().catch(() => {});
+	onMount(async () => {
+		const [t, b] = await Promise.allSettled([fetchLatestTrack(), fetchCurrentBook()]);
+		if (t.status === 'fulfilled' && t.value) track = t.value;
+		if (b.status === 'fulfilled' && b.value) book = b.value;
 	});
 
 	function hideImg(e) {

--- a/src/lib/now.test.ts
+++ b/src/lib/now.test.ts
@@ -8,6 +8,7 @@ import {
   mapTrack,
   mapBook,
   isReading,
+  latestReading,
 } from "./now";
 
 describe("now PDS mappers", () => {
@@ -63,7 +64,39 @@ describe("now PDS mappers", () => {
       title: "Dune",
       author: "Frank Herbert",
       cover: "https://bsky.social/xrpc/com.atproto.sync.getBlob?did=did:plc:abc&cid=bafc",
+      progress: null,
     });
+  });
+
+  it("mapBook passes bookProgress through", () => {
+    const rec = {
+      uri: "at://did:plc:abc/buzz.bookhive.book/1",
+      value: {
+        title: "Recursion",
+        authors: "Blake Crouch",
+        bookProgress: { percent: 60, currentPage: 168, totalPages: 282 },
+      },
+    };
+    expect(mapBook(rec).progress).toEqual({ percent: 60, currentPage: 168, totalPages: 282 });
+  });
+
+  it("latestReading picks the most recently started reading record", () => {
+    const reading = (title: string, startedAt?: string) => ({
+      uri: `at://did:plc:abc/buzz.bookhive.book/${title}`,
+      value: { title, status: "buzz.bookhive.defs#reading", startedAt },
+    });
+    const finished = {
+      uri: "at://did:plc:abc/buzz.bookhive.book/f",
+      value: { title: "Done", status: "buzz.bookhive.defs#finished" },
+    };
+    // A stale reading record (date-only startedAt) must lose to a newer one (ISO datetime).
+    const stale = reading("The Son", "2026-06-23");
+    const current = reading("Recursion", "2026-07-05T06:56:30.807Z");
+    const undated = reading("No Start Date");
+    expect(latestReading([finished, stale, current, undated])?.value.title).toBe("Recursion");
+    expect(latestReading([undated])?.value.title).toBe("No Start Date");
+    expect(latestReading([finished])).toBeNull();
+    expect(latestReading([])).toBeNull();
   });
 
   it("mapTrack maps a teal.fm play record to a view model", () => {

--- a/src/lib/now.ts
+++ b/src/lib/now.ts
@@ -1,10 +1,6 @@
 // Shared PDS fetch + mapping for the /now page widgets, usable both at build
 // time (Astro frontmatter, for instant first paint) and in the browser (the
 // Svelte islands refresh from the same source on mount).
-//
-// ponytail: the small pure helpers are duplicated in the widgets' own client
-// code; kept separate here rather than refactoring three working interactive
-// components. Fold them together when the widgets next get touched.
 
 const HANDLE = "joeinn.es";
 const PDS = "https://bsky.social";
@@ -20,10 +16,16 @@ export interface TrackView {
   artist: string;
   cover: string | null;
 }
+export interface BookProgress {
+  percent?: number;
+  currentPage?: number;
+  totalPages?: number;
+}
 export interface BookView {
   title: string;
   author: string;
   cover: string | null;
+  progress: BookProgress | null;
 }
 interface Record {
   uri: string;
@@ -64,6 +66,23 @@ export function isReading(r: any): boolean {
   return r?.value?.status === READING;
 }
 
+/**
+ * The single book currently being read: the reading-status record with the
+ * most recent startedAt. bookhive leaves stale reading records behind when a
+ * book is re-added and finished under a new record, so "all reading records"
+ * over-reports. startedAt mixes date-only and ISO datetime strings; string
+ * comparison orders both correctly. Records without startedAt sort last.
+ */
+export function latestReading(records: Record[]): Record | null {
+  return (
+    records
+      .filter(isReading)
+      .sort((a, b) =>
+        String(b.value.startedAt ?? "").localeCompare(String(a.value.startedAt ?? "")),
+      )[0] ?? null
+  );
+}
+
 export function mapTrack(r: Record): TrackView {
   return {
     name: r.value.trackName,
@@ -77,6 +96,7 @@ export function mapBook(r: Record): BookView {
     title: r.value.title ?? "Untitled",
     author: authorList(r.value.authors),
     cover: blobUrl(didFromUri(r.uri), r.value.cover),
+    progress: r.value.bookProgress ?? null,
   };
 }
 
@@ -92,8 +112,9 @@ export async function fetchLatestTrack(): Promise<TrackView | null> {
   return r ? mapTrack(r) : null;
 }
 
-export async function fetchReadingBooks(): Promise<BookView[]> {
-  return (await listRecords(BOOK_COLLECTION, 100)).filter(isReading).map(mapBook);
+export async function fetchCurrentBook(): Promise<BookView | null> {
+  const r = latestReading(await listRecords(BOOK_COLLECTION, 100));
+  return r ? mapBook(r) : null;
 }
 
 /** Raw play records (value + rkey) so the widget's existing render code can use them. */

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -7,7 +7,7 @@ import Nav from "../../components/NewNav.astro";
 import RecentTracks from "../../components/RecentTracks.svelte";
 import CurrentlyReading from "../../components/CurrentlyReading.svelte";
 import RightNow from "../../components/RightNow.svelte";
-import { fetchLatestTrack, fetchReadingBooks, fetchRecentTracks } from "../../lib/now";
+import { fetchLatestTrack, fetchCurrentBook, fetchRecentTracks } from "../../lib/now";
 import { fetchNow } from "../../lib/pds";
 
 // Fetch the widgets' data here so the first paint already shows content instead
@@ -21,9 +21,9 @@ async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {
     return fallback;
   }
 }
-const [initialTrack, initialBooks, initialRecentTracks] = await Promise.all([
+const [initialTrack, initialBook, initialRecentTracks] = await Promise.all([
   safe(fetchLatestTrack(), null),
-  safe(fetchReadingBooks(), []),
+  safe(fetchCurrentBook(), null),
   safe(fetchRecentTracks(3), []),
 ]);
 
@@ -48,10 +48,10 @@ const description =
   <Nav />
   <main>
     <h1 class="title">Now</h1>
-    <RightNow client:load initialTrack={initialTrack} initialBook={initialBooks[0] ?? null} />
+    <RightNow client:load initialTrack={initialTrack} initialBook={initialBook} />
     <article set:html={renderedMd} />
     <article>
-      <CurrentlyReading client:load initialBooks={initialBooks} />
+      <CurrentlyReading client:load initialBook={initialBook} />
     </article>
     <article>
       <h2>Listening To...</h2>


### PR DESCRIPTION
## Summary
- The reading widget listed every bookhive record still carrying `reading` status, including stale duplicates of books since finished under a new record; it now shows only the record with the most recent `startedAt`, rendering its `bookProgress` as a progress bar.
- Folds the PDS fetch/mapping logic duplicated across `RightNow` and `CurrentlyReading` into `src/lib/now.ts`.
- Adds the missing /now link to the site nav, and spacing below the Right Now widget.

## Test plan
- [ ] `npm test` — 71 tests pass, including the new `latestReading` and progress-mapping cases
- [ ] Load /now: the Reading section shows a single book with a progress bar, and the nav menu includes "Now"