### PR TITLE
Stop the /now stats widget double-counting plays

### DIFF
--- a/src/components/RecentTracks.svelte
+++ b/src/components/RecentTracks.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { onMount } from 'svelte';
+	import { dedupeTracks } from '../lib/now';
 
 	const HANDLE = 'joeinn.es';
 	const COLLECTION = 'fm.teal.alpha.feed.play';
@@ -17,6 +18,10 @@
 	let allTracks = $state([]);
 	let recentTracks = $state(initialRecentTracks);
 	let loading = $state(initialRecentTracks.length === 0);
+	// Paging must not start until the cache has been loaded into allTracks —
+	// otherwise the first page lands on top of its cached copy and every play
+	// in it is counted twice (and the doubled list gets saved back to the cache).
+	let ready = $state(false);
 	let loadingMore = $state(false);
 	let error = $state('');
 	let selectedPeriod = $state('week');
@@ -102,7 +107,7 @@
 		const res = await fetch(`${PDS}/xrpc/com.atproto.repo.listRecords?${params}`);
 		if (!res.ok) throw new Error(`Failed to fetch tracks (${res.status})`);
 		const data = await res.json();
-		allTracks = [...allTracks, ...data.records.map(toTrack)];
+		allTracks = dedupeTracks([...allTracks, ...data.records.map(toTrack)]);
 		nextCursor = data.cursor;
 		if (!data.cursor) fullyLoaded = true;
 	}
@@ -135,7 +140,7 @@
 			cursor = data.cursor;
 		}
 		if (newRecords.length > 0) {
-			allTracks = [...newRecords, ...allTracks];
+			allTracks = dedupeTracks([...newRecords, ...allTracks]);
 		}
 	}
 
@@ -174,34 +179,29 @@
 		// Load cache for stats if available
 		const cache = await loadCache();
 		if (cache?.tracks?.length) {
-			allTracks = cache.tracks;
+			// dedupe: heal caches poisoned by the old cache-load/paging race
+			allTracks = dedupeTracks(cache.tracks);
 			fullyLoaded = cache.fullyLoaded ?? false;
 			nextCursor = cache.nextCursor;
-			loading = false;
+		}
+		await recentPromise;
+		loading = false;
+		// Paging (the $effect below) takes over from here; on a cache miss it
+		// fetches the first pages, on a hit it only tops up the current period.
+		ready = true;
 
-			await recentPromise;
+		if (allTracks.length) {
 			try {
 				await fetchNewRecords();
 				saveCache();
 			} catch {
 				// Cached data is still shown
 			}
-			return;
-		}
-
-		try {
-			await recentPromise;
-			await fetchPage();
-			saveCache();
-		} catch (e) {
-			error = e.message;
-		} finally {
-			loading = false;
 		}
 	});
 
 	$effect(() => {
-		if (!loading && !loadingMore && !hasEnoughData(selectedPeriod)) {
+		if (ready && !loadingMore && !hasEnoughData(selectedPeriod)) {
 			loadMore();
 		}
 	});

--- a/src/lib/now.test.ts
+++ b/src/lib/now.test.ts
@@ -9,6 +9,7 @@ import {
   mapBook,
   isReading,
   latestReading,
+  dedupeTracks,
 } from "./now";
 
 describe("now PDS mappers", () => {
@@ -97,6 +98,17 @@ describe("now PDS mappers", () => {
     expect(latestReading([undated])?.value.title).toBe("No Start Date");
     expect(latestReading([finished])).toBeNull();
     expect(latestReading([])).toBeNull();
+  });
+
+  it("dedupeTracks drops records sharing an rkey, keeping the first occurrence", () => {
+    const a1 = { _rkey: "a", trackName: "First" };
+    const a2 = { _rkey: "a", trackName: "Duplicate" };
+    const b = { _rkey: "b", trackName: "Other" };
+    const noKey = { trackName: "No rkey" };
+    // A play-history list where a page was double-appended must collapse back
+    // to one record per rkey; records without an rkey are always kept.
+    expect(dedupeTracks([a1, b, a2, noKey, noKey])).toEqual([a1, b, noKey, noKey]);
+    expect(dedupeTracks([])).toEqual([]);
   });
 
   it("mapTrack maps a teal.fm play record to a view model", () => {

--- a/src/lib/now.ts
+++ b/src/lib/now.ts
@@ -117,6 +117,21 @@ export async function fetchCurrentBook(): Promise<BookView | null> {
   return r ? mapBook(r) : null;
 }
 
+/**
+ * Drop play records sharing an _rkey, keeping the first occurrence. Guards the
+ * stats widget's accumulated history against double-appending a page (e.g. a
+ * fetch racing the cache load), and heals caches already poisoned by it.
+ */
+export function dedupeTracks<T extends { _rkey?: string }>(tracks: T[]): T[] {
+  const seen = new Set<string>();
+  return tracks.filter((t) => {
+    if (!t._rkey) return true;
+    if (seen.has(t._rkey)) return false;
+    seen.add(t._rkey);
+    return true;
+  });
+}
+
 /** Raw play records (value + rkey) so the widget's existing render code can use them. */
 export async function fetchRecentTracks(limit = 3): Promise<any[]> {
   return (await listRecords(PLAY_COLLECTION, limit)).map((r) => ({


### PR DESCRIPTION
## Summary
- Server-seeding the widget made `loading` start `false`, so the paging `$effect` fired before the async IndexedDB cache read finished: the newest page of plays was appended on top of its cached copy, and the doubled history was saved back to the cache — permanently doubling every play count in the stats.
- Paging is now gated behind a `ready` flag set once the cache has loaded, and a unit-tested `dedupeTracks()` enforces one-record-per-rkey everywhere the history grows, which also heals already-poisoned caches on the next visit.

## Test plan
- [ ] `npm test` — 72 tests pass, including the new `dedupeTracks` invariant
- [ ] Load /now with a poisoned cache: stats counts match the PDS (e.g. "All For Nothing" shows 2 plays, not 4); reload and confirm counts stay correct